### PR TITLE
Indent the child modules' size percentage

### DIFF
--- a/utils/format-modules.js
+++ b/utils/format-modules.js
@@ -48,7 +48,7 @@ function printDependencySizeTree(node, depth, outputFn) {
   for (var child of childrenBySize) {
     ++includedCount;
     var percentage = ((child.size/totalSize) * 100).toPrecision(3);
-    outputFn([`${prefix}${child.packageName}`, `${filesize(child.size)}`, `${prefix}${percentage}%`]);
+    outputFn([`${prefix}${child.packageName}`, `${prefix}${filesize(child.size)}`, `${prefix}${percentage}%`]);
 
     printDependencySizeTree(child, depth + 1, outputFn);
 
@@ -61,7 +61,7 @@ function printDependencySizeTree(node, depth, outputFn) {
 
   if (depth === 0 || remainder !== totalSize) {
     const percentage = ((remainder/totalSize) * 100).toPrecision(3);
-    outputFn([`${prefix}<self>`, `${filesize(remainder)}`, `${prefix}${percentage}%`]);
+    outputFn([`${prefix}<self>`, `${prefix}${filesize(remainder)}`, `${prefix}${percentage}%`]);
   }
 }
 

--- a/utils/format-modules.js
+++ b/utils/format-modules.js
@@ -48,7 +48,7 @@ function printDependencySizeTree(node, depth, outputFn) {
   for (var child of childrenBySize) {
     ++includedCount;
     var percentage = ((child.size/totalSize) * 100).toPrecision(3);
-    outputFn([`${prefix}${child.packageName}`, `${filesize(child.size)}`, `${percentage}%`]);
+    outputFn([`${prefix}${child.packageName}`, `${filesize(child.size)}`, `${prefix}${percentage}%`]);
 
     printDependencySizeTree(child, depth + 1, outputFn);
 
@@ -61,7 +61,7 @@ function printDependencySizeTree(node, depth, outputFn) {
 
   if (depth === 0 || remainder !== totalSize) {
     const percentage = ((remainder/totalSize) * 100).toPrecision(3);
-    outputFn([`${prefix}<self>`, `${filesize(remainder)}`, `${percentage}%`]);
+    outputFn([`${prefix}<self>`, `${filesize(remainder)}`, `${prefix}${percentage}%`]);
   }
 }
 


### PR DESCRIPTION
Before:
<img width="1439" alt="screen shot 2016-08-14 at 2 33 00 pm" src="https://cloud.githubusercontent.com/assets/5377524/17651447/bfaa388c-622c-11e6-9923-87fea22d6f23.png">
After:
<img width="1427" alt="screen shot 2016-08-14 at 2 33 42 pm" src="https://cloud.githubusercontent.com/assets/5377524/17651448/c3bc8bbe-622c-11e6-968f-49425aab67c9.png">

Before, it was slightly confusing, because I was quickly scanning the
percentages and didn't know why a module down the list was at 90%,
before realizing it was 90% of its dependent module. Now it should be
more immediately obvious.

Cheers, I already plan on using this by default for all of my projects! :beers: