### PR TITLE
Fix padding for iTerm

### DIFF
--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -213,7 +213,9 @@ Dashboard.prototype.layoutStatus = function() {
     parent: this.wrapper,
     label: 'Status',
     tags: true,
-    padding: 1,
+    padding: {
+      left: 1,
+    },
     width: '100%',
     height: '34%',
     valign: "middle",
@@ -232,7 +234,9 @@ Dashboard.prototype.layoutStatus = function() {
     parent: this.wrapper,
     label: 'Operation',
     tags: true,
-    padding: 1,
+    padding: {
+      left: 1,
+    },
     width: '100%',
     height: '34%',
     valign: "middle",


### PR DESCRIPTION
Fixes padding so status and operation will display

Found the issue is from having both a top and bottom padding of 1

Refs: https://github.com/FormidableLabs/webpack-dashboard/issues/19