### PR TITLE
Note that scrolling does not work in Terminal.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Finally, start your server using whatever command you have set up. Either you ha
 
 Then, sit back and pretend you're an astronaut.
 
+Note that terminal mouse events are not currently supported by the default OSX Terminal.app. While the rest of the dashboard works correctly, if you wish to scroll through the logs and modules, you may want to use an alternative such as [iTerm2](https://www.iterm2.com/index.html)
+
 #### Credits
 
 Module output deeply inspired by: [https://github.com/robertknight/webpack-bundle-size-analyzer](https://github.com/robertknight/webpack-bundle-size-analyzer)


### PR DESCRIPTION
Took a small amount of digging to learn there wasn't anything wrong with my setup other than Terminal.app in OSX does not support mouse events at all. This PR simply adds a small note to that extent in the 'run' section.