### PR TITLE
Filter curly braces from logs

### DIFF
--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -88,7 +88,8 @@ Dashboard.prototype.setData = function(dataArr) {
         break;
       }
       case "log": {
-        self.logText.log(data.value);
+        var filteredValue = data.value.replace(/[{}]/g, "");
+        self.logText.log(filteredValue);
         break;
       }
       case "clear": {


### PR DESCRIPTION
After I tried to run webpack-dashboard it immediately crashed with this exception:

```TypeError: Cannot read property 'slice' of null
    at /Users/charud/dev/open/node_modules/blessed/lib/program.js:2543:35
    at Array.forEach (native)
    at Program._attr (/Users/charud/dev/open/node_modules/blessed/lib/program.js:2542:11)
    at ScrollableBox.Element._parseTags (/Users/charud/dev/open/node_modules/blessed/lib/widgets/element.js:498:26)
    at ScrollableBox.Element.parseContent (/Users/charud/dev/open/node_modules/blessed/lib/widgets/element.js:393:22)
    at ScrollableBox.Element.setContent (/Users/charud/dev/open/node_modules/blessed/lib/widgets/element.js:335:8)
    at ScrollableBox.Element.insertLine (/Users/charud/dev/open/node_modules/blessed/lib/widgets/element.js:2383:8)
    at ScrollableBox.Element.pushLine (/Users/charud/dev/open/node_modules/blessed/lib/widgets/element.js:2526:15)
    at ScrollableBox.Log.log.Log.add (/Users/charud/dev/open/node_modules/blessed/lib/widgets/log.js:61:18)
    at /Users/charud/dev/open/node_modules/webpack-dashboard/dashboard/index.js:91:22```

It turns out that log messages with curly braces get parsed wrongly and throws this exception. Escaping them with backslash did not help, so instead this PR will filter them out.

This could potentially mess up coloring of logs (that makes use of it). 
Any advice where else this filter could go in that case?