### PR TITLE
Switch from json-socket to socket.io

### DIFF
--- a/bin/webpack-dashboard.js
+++ b/bin/webpack-dashboard.js
@@ -5,8 +5,7 @@ var commander = require("commander");
 var spawn = require("cross-spawn");
 var supportsColor = require("supports-color");
 var Dashboard = require("../dashboard/index.js");
-var net = require("net");
-var JsonSocket = require("json-socket");
+var SocketIO = require("socket.io");
 
 var program = new commander.Command("webpack-dashboard");
 
@@ -42,10 +41,8 @@ var dashboard = new Dashboard({
 });
 
 var port = program.port || 9838;
-var server = net.createServer();
-server.listen(port);
+var server = SocketIO(port);
 server.on("connection", function(socket) {
-  socket = new JsonSocket(socket);
   socket.on("message", function(message) {
     dashboard.setData(message);
   });

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "commander": "^2.9.0",
     "cross-spawn": "^4.0.0",
     "filesize": "^3.3.0",
-    "json-socket": "^0.1.2",
+    "socket.io": "^1.4.8",
     "supports-color": "^3.1.2",
     "webpack": "^1.13.1"
   }

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -3,7 +3,7 @@
 
 var webpack = require("webpack");
 var net = require("net");
-var JsonSocket = require("json-socket");
+var SocketIOClient = require("socket.io-client");
 
 function noop() {}
 
@@ -24,10 +24,9 @@ DashboardPlugin.prototype.apply = function(compiler) {
     handler = noop;
     var port = this.port;
     var host = "127.0.0.1";
-    var socket = new JsonSocket(new net.Socket());
-    socket.connect(port, host);
+    var socket = SocketIOClient("http://" + host + ":" + port);
     socket.on("connect", function() {
-      handler = socket.sendMessage.bind(socket);
+      handler = socket.emit.bind(socket, "message");
     });
   }
 


### PR DESCRIPTION
Per #72, `json-socket` has issues with multibyte characters in large messages. I already made a pull request to fix the issue upstream, but I'm not optimistic about it being merged.

`socket.io` appears to be much more actively maintained and properly supports the messages `json-socket` was having problems with (and it was mostly a 1:1 replacement).