### PR TITLE
Only append --color to args if webpack is the command being called

### DIFF
--- a/bin/webpack-dashboard.js
+++ b/bin/webpack-dashboard.js
@@ -27,8 +27,8 @@ var command = program.args[0];
 var args = program.args.slice(1);
 var env = {};
 
-if (supportsColor) {
-  //args.push("--color");
+if (supportsColor && command === 'webpack') {
+  args.push("--color");
 }
 
 var child = spawn(command, args, {


### PR DESCRIPTION
Since you're probably doing `--color` for the `webpack` command.

---

On a side note, why even append `--color` at all anyway? All it does is override the webpack config, which you can make colors work on regardless of what happens by setting `stats.colors` to `true` and/or `devServer.stats.colors` to `true`.