### PR TITLE
add socket.io-client as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "cross-spawn": "^4.0.0",
     "filesize": "^3.3.0",
     "socket.io": "^1.4.8",
+    "socket.io-client": "^1.4.8",
     "webpack": "^1.13.1"
   }
 }


### PR DESCRIPTION

![screen shot 2016-08-19 at 5 24 05 pm](https://cloud.githubusercontent.com/assets/7219131/17824663/63e014e6-6631-11e6-9464-35996cede36e.png)


After running `npm install webpack-dashboard@0.1.5` to upgrade from 0.1.4 and starting webpack as usual, I receive the error message 

```
Error: Cannot find module 'socket.io-client'
...
...
at Object.<anonymous> (.../node_modules/webpack-dashboard/plugin/index.js:6:22)
```

After `cd`ing into node_modules/webpack-dashboard/ and running `npm install --save socket.io-client` webpack dashboard works as usual