### PR TITLE
remove es6 syntax, fixes #126

### DIFF
--- a/utils/format-modules.js
+++ b/utils/format-modules.js
@@ -139,7 +139,7 @@ function bundleSizeTree(stats) {
         }
         var newChild = {
           packageName: pkg,
-          packageVersion,
+          packageVersion: packageVersion,
           size: mod.size,
           children: []
         };


### PR DESCRIPTION
this will make `webpack-dashboard` working on older version of nodejs.