### PR TITLE
Get log directly from Webpack

### DIFF
--- a/bin/webpack-dashboard.js
+++ b/bin/webpack-dashboard.js
@@ -17,22 +17,25 @@ program.option("-p, --port [port]", "Socket listener port");
 program.usage("[options] -- [script] [arguments]");
 program.parse(process.argv);
 
+var logFromChild = true;
+
 if (!program.args.length) {
-  program.outputHelp();
-  return;
+  logFromChild = false;
 }
 
-var command = program.args[0];
-var args = program.args.slice(1);
-var env = process.env;
-
-env.FORCE_COLOR = true;
-
-var child = spawn(command, args, {
-  env: env,
-  stdio: [null, null, null, null],
-  detached: true
-});
+if(logFromChild) {
+  var command = program.args[0];
+  var args = program.args.slice(1);
+  var env = process.env;
+  
+  env.FORCE_COLOR = true;
+  
+  var child = spawn(command, args, {
+    env: env,
+    stdio: [null, null, null, null],
+    detached: true
+  });
+}
 
 var dashboard = new Dashboard({
   color: program.color || "green",
@@ -42,30 +45,44 @@ var dashboard = new Dashboard({
 
 var port = program.port || 9838;
 var server = SocketIO(port);
-server.on("connection", function(socket) {
-  socket.on("message", function(message) {
-    dashboard.setData(message);
-  });
-});
 
 server.on("error", function(err) {
   console.log(err);
 });
 
-child.stdout.on("data", function (data) {
-  dashboard.setData([{
-    type: "log",
-    value: data.toString("utf8")
-  }]);
-});
 
-child.stderr.on("data", function (data) {
-  dashboard.setData([{
-    type: "log",
-    value: data.toString("utf8")
-  }]);
-});
 
-process.on("exit", function () {
-  process.kill(process.platform === "win32" ? child.pid : -child.pid);
-});
+if(logFromChild) {
+  server.on("connection", function(socket) {
+    socket.on("message", function(message) {
+      if(message.type !== "log") {
+        dashboard.setData(message);
+      }
+    });
+  });
+
+  child.stdout.on("data", function (data) {
+    dashboard.setData([{
+      type: "log",
+      value: data.toString("utf8")
+    }]);
+  });
+  
+  child.stderr.on("data", function (data) {
+    dashboard.setData([{
+      type: "log",
+      value: data.toString("utf8")
+    }]);
+  });
+
+  process.on("exit", function () {
+    process.kill(process.platform === "win32" ? child.pid : -child.pid);
+  });
+} else {
+  server.on("connection", function(socket) {
+    socket.on("message", function(message) {
+      dashboard.setData(message);
+    });
+  });
+}
+

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -98,6 +98,9 @@ DashboardPlugin.prototype.apply = function(compiler) {
         warnings: stats.hasWarnings(),
         data: stats.toJson()
       }
+    }, {
+      type: "log",
+      value: stats.toString({colors: true})
     }]);
   });
 


### PR DESCRIPTION
## Disclaimer

This pull request is not meant to be merged as-is.
The code is a bit ugly and needs reviewing.
It is however a working implementation.

## The changes

Now, webpack-dashboard can get the logs directly from Webpack.
Instead of using 2 IPCs (standard output for logs, sockets for everything else) you can now use sockets only.

## Usage

To use this, just omit the child command. Hence, the usage would be:

```
webpack-dashboard
```

or, for a specific port, say 3001

```
webpack-dasboard --port 3001
```

## Motivation

I needed this for myself, and here's why.

### Remote webpack process

I run webpack in a container. It is much easier for me to simply connect to the socket than it is to redirect the standard output properly. I first tried that but ended up with contrived commands (and loss of color output).

### Multiple webpack entries/outputs

I have a single webpack process that produces two bundles ; one for my app's server, the other for my app's client. Using webpack-dashboard the current way, only data from the last working bundle is processed. A workaround is to specify a different port for each bundle and open webpack-dashboard in two terminals (each connected to a different socket). Problem is, because there is a single webpack process, you can only get the logs for one of those. And nothing guarantees that the logs will match the bundle you're connected to.

### More flexible output

I don't have a use case for this but the issue #138 asks for custom log output.
With this change, it would be done like so:

```
webpack --watch > /dev/null &
webpack-dashboard -- <command>
```

where `<command>` is a command that outputs custom logs in standard output.

## The code

I think this design is simpler and more elegant. However, the code is not that great.

In `bin/webpack` there is a bunch of ugly `if` statements. If you want to see the behavior I propose implemented, some guidance on how to fix this is very welcome.

In `plugin/index.js`, the plugin sends the log output trough the socket when the `done` event occurs. This is very simple but wasteful in the case when this it ends up being ignored. I don't think this is an issue but it's worth being mentioned.