### PR TITLE
[WIP] Webpack doesn't exit #151

### DIFF
--- a/bin/webpack-dashboard.js
+++ b/bin/webpack-dashboard.js
@@ -78,7 +78,9 @@ if (logFromChild) {
   });
 
   process.on("exit", () => {
-    process.kill(process.platform === "win32" ? child.pid : -child.pid);
+    try {
+      process.kill(process.platform === "win32" ? child.pid : -child.pid);
+    } catch (e) {} // eslint-disable-line no-empty
   });
 } else {
   server.on("connection", (socket) => {

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -69,6 +69,7 @@ class Dashboard {
         stats: this.setStats.bind(this),
         log: this.setLog.bind(this),
         clear: this.clear.bind(this),
+        exit: this.exit.bind(this),
         sizes: _data => {
           if (this.minimal) { return; }
           if (_data.value instanceof Error) {
@@ -101,6 +102,15 @@ class Dashboard {
     this.screen.render();
   }
 
+  exit(error) {
+    if (error) {
+      throw error;
+    } else {
+      // eslint-disable-next-line no-process-exit
+      process.exit(0);
+    }
+
+  }
   setProgress(data) {
     const percent = parseInt(data.value * PERCENT_MULTIPLIER, 10);
     const formattedPercent = `${percent.toString()}%`;


### PR DESCRIPTION
**Work in progress. Do not merge 😉** 

Detecting if we are running the webpack-dev-server or just a reg'lar old webpack build is _tricky_. The web socket appears to what keeps the app up, so killing that off, and gracefully killing off the blessed console seems to work fine. The problem is that detecting whether or not we are in a webpack dev server is rather _difficult_. I've got a semi-fragile method that works for webpack 2, need to see if it will work for webpack 1. Should be able to take another look at this on Tuesday. 


