### PR TITLE
Don't parse sourcemaps!

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -39,7 +39,10 @@ function getBundleMetrics(stats, inspectpack, handler) {
     .filter(bundlePath =>
       // Don't include hot reload assets, they break everything
       // and the updates are already included in the new assets
-      bundlePath.indexOf(".hot-update.") === -1
+      bundlePath.indexOf(".hot-update.") === -1 &&
+
+      // Don't parse sourcemaps!
+      path.extname(bundlePath) === ".js"
     )
     .map(bundlePath => ({
       path: bundlePath,


### PR DESCRIPTION
Tried the new alpha against https://github.com/andrewngu/sound-redux and it had parse errors (not the first report of these). Turns out that we're trying to parse sourcemaps (oops). Now we don't and everything's peachy!