### PR TITLE
Fix for #151: Webpack doesn't exit

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -134,6 +134,7 @@ class DashboardPlugin {
       socket.on("connect", () => {
         handler = socket.emit.bind(socket, "message");
       });
+      this.socket = socket;
     }
 
     compiler.apply(new webpack.ProgressPlugin((percent, msg) => {
@@ -150,6 +151,7 @@ class DashboardPlugin {
     }));
 
     compiler.plugin("watch-run", (c, done) => {
+      this.watching = true;
       InspectpackDaemon.init({ cacheDir }).then(inspectpack => {
         this.inspectpack = inspectpack;
         done();
@@ -216,6 +218,13 @@ class DashboardPlugin {
         type: "log",
         value: stats.toString(statsOptions)
       }]);
+
+      if (!this.watching) {
+        if (this.socket) {
+          this.socket.close();
+        }
+        return;
+      }
 
       getBundleMetrics(stats, this.inspectpack, handler);
     });


### PR DESCRIPTION
If `DashboardPlugin()` is left in the plugins on a non-watching build an open websocket prevents webpack from exiting on completion. This update will close down the socket if it exists and we aren't in watch mode. 

/cc @kenwheeler 