### PR TITLE
Stream actions with completion to the socket

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "handlebars": "^4.0.6",
     "inspectpack": "^1.2.0",
     "lodash": "^4.17.4",
+    "most": "^1.6.1",
     "socket.io": "^1.4.8",
     "socket.io-client": "^1.4.8",
     "webpack": "^2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,16 @@
 # yarn lockfile v1
 
 
+"@most/multicast@^1.2.5":
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/@most/multicast/-/multicast-1.2.5.tgz#ba5abc997f9a6511094bec117914f4959720a8fb"
+  dependencies:
+    "@most/prelude" "^1.4.0"
+
+"@most/prelude@^1.4.0":
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.6.2.tgz#e022db0a3522ea45a427f739570b99f6a6b49162"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -2117,6 +2127,14 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
+most@^1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/most/-/most-1.6.1.tgz#2a245adcc7f88617b0a63167cb76bc1fc08a9d0a"
+  dependencies:
+    "@most/multicast" "^1.2.5"
+    "@most/prelude" "^1.4.0"
+    symbol-observable "^1.0.2"
+
 ms@0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
@@ -3041,6 +3059,10 @@ supports-color@^3.1.0, supports-color@^3.1.1:
   dependencies:
     has-flag "^1.0.0"
 
+symbol-observable@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
@@ -3368,9 +3390,9 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
-"workerpool@git+https://github.com/FormidableLabs/workerpool.git#71d4e17":
+"workerpool@https://github.com/FormidableLabs/workerpool#71d4e17":
   version "2.2.0"
-  resolved "git+https://github.com/FormidableLabs/workerpool.git#71d4e17"
+  resolved "https://github.com/FormidableLabs/workerpool#71d4e17"
   dependencies:
     object-assign "^4.1.1"
 


### PR DESCRIPTION
This allows the `sizes` action to emit to the dashboard before the "problem" actions (which take a good bit more time). We lost this "streaming" in #178 because we needed completion semantics to clear up the socket/inspectpack daemon. Now we can emit messages independently _and_ know when they're complete!

This could also open up more granular streaming, e.g. spit out each bundle's size as soon as we know it instead of `Promise.all`ing it.