### PR TITLE
Feature - Add plugin host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Then, sit back and pretend you're an astronaut.
  - `-c, --color [color]` - Custom ANSI color for your dashboard
  - `-m, --minimal` - Runs the dashboard in minimal mode
  - `-t, --title [title]` - Set title of terminal window
- - `-p, --port [port]` - Custom port for socket communication
+ - `-p, --port [port]` - Custom port for socket communication server
 
 ##### Arguments
 
@@ -82,7 +82,8 @@ Then, sit back and pretend you're an astronaut.
 #### Webpack plugin
 #### Options
 
- - `port` - Custom port for socket communication
+ - `port` - Custom port for connecting the socket client
+ - `host` - Custom host for connection the socket client
  - `handler` - Plugin handler method, i.e. `dashboard.setData`
 
 *Note: you can also just pass a function in as an argument, which then becomes the handler, i.e. `new DashboardPlugin(dashboard.setData)`*

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -12,6 +12,7 @@ const InspectpackDaemon = require('inspectpack').daemon;
 const serializeError = require('../utils/error-serialization').serializeError;
 
 const DEFAULT_PORT = 9838;
+const DEFAULT_HOST = '127.0.0.1';
 const ONE_SECOND = 1000;
 const INSPECTPACK_PROBLEM_ACTIONS = ['versions', 'duplicates'];
 const INSPECTPACK_PROBLEM_TYPE = 'problems';
@@ -122,6 +123,7 @@ class DashboardPlugin {
     } else {
       options = options || {};
       this.port = options.port || DEFAULT_PORT;
+      this.host = options.host || DEFAULT_HOST;
       this.handler = options.handler || null;
     }
 
@@ -152,7 +154,7 @@ class DashboardPlugin {
     if (!handler) {
       handler = noop;
       const port = this.port;
-      const host = '127.0.0.1';
+      const host = this.host;
       this.socket = new SocketIOClient(`http://${host}:${port}`);
       this.socket.on('connect', () => {
         handler = this.socket.emit.bind(this.socket, 'message');

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -12,7 +12,7 @@ const InspectpackDaemon = require("inspectpack").daemon;
 const serializeError = require("../utils/error-serialization").serializeError;
 
 const DEFAULT_PORT = 9838;
-const DEFAULT_HOST = '127.0.0.1';
+const DEFAULT_HOST = "127.0.0.1";
 const ONE_SECOND = 1000;
 const INSPECTPACK_PROBLEM_ACTIONS = ["versions", "duplicates"];
 const INSPECTPACK_PROBLEM_TYPE = "problems";


### PR DESCRIPTION
I work on many projects at same time, to not deal with port issues on them I usually dockerize the servers (a small performance trade-off for the convenience).

The problem is that the best place to run the **webpack-dashboard** server is in my local terminal and the new **electrum-webpack-dashboard** we have no choice...

As a solution, we can add the option to change where the client will connect, in this case, I can expose my host IP to the container, and it will connect the port and provide the socket communication.

In the documentation, I have added the `host` option and a bit of clarification of what is server and what is client in this project. I know many people don't care, but that would save me a lot of time to understand how it works, instead of going to the source code to figure out.

I really appreciate the work in this plugin and hope to help with this contribution.