### PR TITLE
Add more project root inference for `versions` (aka `Unable to find project root package.json` issue)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Then, sit back and pretend you're an astronaut.
 #### Options
 
  - `port` - Custom port for socket communication
+ - `root` - Custom full path to project root (where `package.json` + `node_modules` are if not in `process.cwd()`)
  - `handler` - Plugin handler method, i.e. `dashboard.setData`
 
 *Note: you can also just pass a function in as an argument, which then becomes the handler, i.e. `new DashboardPlugin(dashboard.setData)`*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "webpack-dashboard",
-  "version": "1.0.0-5",
+  "version": "1.0.0-6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -397,6 +397,17 @@
         "callsite": "1.0.0"
       }
     },
+    "better-sqlite3": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-4.0.2.tgz",
+      "integrity": "sha512-WoUXe6CFJ1ncxTPvWgGmg0TBGVaj/kMPcUfYJtf3KA4WrrtL4OVH+1RDhe5miKly3VO+BJ35t+a7xNGDVU7Qww==",
+      "requires": {
+        "bindings": "1.3.0",
+        "integer": "1.0.1",
+        "lzz-gyp": "0.3.5",
+        "to-descriptor": "1.0.1"
+      }
+    },
     "big.js": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
@@ -408,6 +419,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
       "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw=="
     },
     "blessed": {
       "version": "0.1.81",
@@ -1433,6 +1449,15 @@
         "is-extglob": "1.0.0"
       }
     },
+    "farmhash": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/farmhash/-/farmhash-1.2.1.tgz",
+      "integrity": "sha1-Lb8SYE71yh8UIPtmAPzLMNVHTf0=",
+      "optional": true,
+      "requires": {
+        "nan": "2.7.0"
+      }
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -1775,19 +1800,28 @@
       }
     },
     "inspectpack": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/inspectpack/-/inspectpack-1.3.2.tgz",
-      "integrity": "sha1-CcL1M6VZI20VFMcg58ZdEnUVkAg=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/inspectpack/-/inspectpack-2.0.0.tgz",
+      "integrity": "sha512-4OMYGwF4ZIqwMhKyeA9tXYsStPNSYuNxX9M64v2Ai/c97q8cp+H4XPDn/8EAN281ofp2VORLPzOShvQHGrbFtA==",
       "requires": {
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
+        "better-sqlite3": "4.0.2",
+        "farmhash": "1.2.1",
         "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
         "pify": "2.3.0",
         "uglify-es": "3.0.28",
         "workerpool": "2.2.4",
         "yargs": "4.8.1"
+      }
+    },
+    "integer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/integer/-/integer-1.0.1.tgz",
+      "integrity": "sha1-Qey125kxwaBpco9HZPjX7u4Cskk=",
+      "requires": {
+        "bindings": "1.3.0"
       }
     },
     "interpret": {
@@ -2194,6 +2228,11 @@
         "yallist": "2.1.2"
       }
     },
+    "lzz-gyp": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/lzz-gyp/-/lzz-gyp-0.3.5.tgz",
+      "integrity": "sha1-DsZ9APS9qlvFxe7NHrO+7RgQMuU="
+    },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
@@ -2323,6 +2362,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
       "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+      "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -3235,6 +3280,15 @@
         "xtend": "4.0.1"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -3243,15 +3297,6 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
@@ -3370,6 +3415,11 @@
       "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
       "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
       "dev": true
+    },
+    "to-descriptor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-descriptor/-/to-descriptor-1.0.1.tgz",
+      "integrity": "sha1-oOZ4w068fS2uRk2DcrwhR52cK80="
     },
     "to-fast-properties": {
       "version": "1.0.3",

--- a/utils/format-problems.js
+++ b/utils/format-problems.js
@@ -6,7 +6,11 @@ const formatVersions = require("./format-versions");
 
 function formatProblems(bundle) {
   const duplicates = formatDuplicates(bundle.duplicates);
-  const versions = formatVersions(bundle.versions);
+  // Versions may be undefined if we couldn't get a project root.
+  const versions = typeof bundle.versions === "undefined" ?
+    `${chalk.yellow("Unable to diagnose possible version skews\n")}` :
+    formatVersions(bundle.versions);
+
   if (!duplicates && !versions) {
     return chalk.green("No problems detected!");
   }
@@ -16,7 +20,8 @@ function formatProblems(bundle) {
   if (!duplicates && versions) {
     return `${chalk.green("No duplicate files!")}\n${versions}`;
   }
-  return `${formatDuplicates(bundle.duplicates)}\n${formatVersions(bundle.versions)}`;
+
+  return `${duplicates}\n${versions}`;
 }
 
 module.exports = formatProblems;

--- a/utils/format-versions.js
+++ b/utils/format-versions.js
@@ -18,7 +18,7 @@ const template = Handlebars.compile(
 `);
 
 function formatVersions(versions) {
-  return versions.versions.length && template({
+  return ((versions || {}).versions || []).length && template({
     versions: versions.versions
   }) || "";
 }


### PR DESCRIPTION
We have a bug opened in `inspectpack` repo that is really a `webpack-dashboard` issue. Fixes https://github.com/FormidableLabs/inspectpack/issues/45

The `inspectpack` `versions` action detects versions skews in installed packages within a webpack bundle by actually traversing the `node_modules` installed from the "project root" which is basically the directory that contains the operating `package.json`.

Some bespoke webpack configurations change `bundle.context` to something _other_ than a directory that is our "project root". This causes `inspectpack` to rightfully bomb out with a `Error: Unable to find project root package.json` error -- because if you're running `versions` you need to have this accessible.

In `webpack-dashboard`-land, it pays to be a little more permissive, because folks might not mind missing `versions` for getting all the _other_ cool dashboard stuff. So, accordingly, here's how the dashboard now deals with the problem:

1. If the `DashboardPlugin` specifies a `root` option to the root project directory, we use that. **Note**: We don't _check_ it's valid -- if it's invalid and manually specified you **will** get this same error.
2. If no `root` is specified, try to see if `bundle.context` has a `package.json`, use that.
3. If `bundle.context` isn't workable, try `process.cwd()`.
4. If `process.cwd()` isn't usable, then just _disable_ the `versions` action for the dashboard.

So, looking at @derkjn 's handy error repro repo https://github.com/derkjn/webpack-dashboard-error let's assume we are running webpack / commands from this directory:

https://github.com/derkjn/webpack-dashboard-error/tree/master/web/app/themes/ignitetheme

Then, we can edit https://github.com/derkjn/webpack-dashboard-error/blob/master/web/app/themes/ignitetheme/resources/assets/build/webpack.config.js with any of the following options and it will work without error:

Just like it exists now. Works because `process.cwd()` is used.

```js
  new DashboardPlugin()
```

Manually specify a root. These all basically resolve to `/web/app/themes/ignitetheme`.

```js
  new DashboardPlugin({
    root: process.cwd()
  })
```

```js
  new DashboardPlugin({
    // webpack config is three levels deeper than CWD
    root:  path.resolve(__dirname, "../../..")
  })
```

```js
  new DashboardPlugin({
    // This was set in a different file to the same thing.
    root: config.paths.root
  })
```

@derkjn -- Can you confirm this new version of `webpack-dashboard` now fixes your error?

/cc @kenwheeler @tptee 