### PR TITLE
Fixed minimal sizing of the 3 lower boxes

### DIFF
--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -414,7 +414,7 @@ class Dashboard {
       padding: {
         left: 1
       },
-      width: this.minimal ? "34%" : "100%",
+      width: this.minimal ? "34%-1" : "100%",
       height: this.minimal ? "100%" : "34%",
       valign: "middle",
       border: {
@@ -435,7 +435,7 @@ class Dashboard {
       padding: {
         left: 1
       },
-      width: this.minimal ? "34%" : "100%",
+      width: this.minimal ? "34%-1" : "100%",
       height: this.minimal ? "100%" : "34%",
       valign: "middle",
       border: {


### PR DESCRIPTION
Minor fix to allow boxes to have a `-1` offset to fit all three boxes in one row depending on the sizing of the terminal window.

Depending on the size of the window, the three sizes of `34%`, `34%` and `33%` can cause an overflow. Testing different sizing configurations, `34%-1`, `34%-1` and `33%` had the most consistent results of always showing all three boxes on the same row and it consuming most of the full width.

Tested in both Terminal and iTerm.

Addresses https://github.com/FormidableLabs/webpack-dashboard/issues/174

![t](https://user-images.githubusercontent.com/1738349/31091439-d8300f5c-a75f-11e7-8100-988257a7e4f0.gif)
<img width="2642" alt="screen shot 2017-10-02 at 10 51 35 am" src="https://user-images.githubusercontent.com/1738349/31091441-da2c60ee-a75f-11e7-817b-e71d2770a581.png">

cc @ryan-roemer @kenwheeler 