### PR TITLE
Do not output log when errors are present.

### DIFF
--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -225,7 +225,9 @@ class Dashboard {
   }
 
   setLog(data) {
-    this.logText.log(data.value.replace(/[{}]/g, ""));
+    if (!this.stats.hasErrors()) {
+      this.logText.log(data.value.replace(/[{}]/g, ""));
+    }
   }
 
   clear() {


### PR DESCRIPTION
Since we parse and display errors in `setStats(data)` to the log with `this.logText.log(formatOutput(stats))`, the errors from the normal log duplicate the messages with extra output. The simple fix is to not log output when we have errors we parsed and are displaying.

Addresses https://github.com/FormidableLabs/webpack-dashboard/issues/66

**Success**
<img width="1050" alt="screen shot 2017-10-02 at 3 03 32 pm" src="https://user-images.githubusercontent.com/1738349/31101675-a406e79a-a783-11e7-8401-43cf8ca3efa5.png">

**Failure**
<img width="1050" alt="screen shot 2017-10-02 at 3 03 48 pm" src="https://user-images.githubusercontent.com/1738349/31101704-b4cebac6-a783-11e7-904e-3ae25bcd236e.png">

cc @ryan-roemer @kenwheeler 