### PR TITLE
Fix WP 3 size reporting, disable inspectpack in minimal

### DIFF
--- a/bin/webpack-dashboard.js
+++ b/bin/webpack-dashboard.js
@@ -56,6 +56,8 @@ server.on("error", (err) => {
 
 if (logFromChild) {
   server.on("connection", (socket) => {
+    socket.emit("mode", { minimal: program.minimal || false });
+
     socket.on("message", (message) => {
       if (message.type !== "log") {
         dashboard.setData(message);

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -72,6 +72,10 @@ class Dashboard {
         sizes: _data => {
           if (this.minimal) { return; }
           if (_data.value instanceof Error) {
+            if (_data.value.message === "No code sections found") {
+              this.setProductionSizesWarning();
+              return;
+            }
             this.setSizesError(_data.value);
           } else {
             this.setSizes(_data);
@@ -80,6 +84,10 @@ class Dashboard {
         problems: _data => {
           if (this.minimal) { return; }
           if (_data.value instanceof Error) {
+            if (_data.value.message === "No code sections found") {
+              this.setProductionProblemsWarning();
+              return;
+            }
             this.setProblemsError(_data.value);
           } else {
             this.setProblems(_data);
@@ -195,6 +203,23 @@ class Dashboard {
     this.assets.setLabel(chalk.red("Assets (error)"));
     this.logText.log(chalk.red("Could not load module/asset sizes."));
     this.logText.log(chalk.red(err));
+  }
+
+  setProductionSizesWarning() {
+    this.modulesMenu.setLabel(chalk.yellow("Modules (warning)"));
+    this.assets.setLabel(chalk.yellow("Assets (warning)"));
+    this.moduleTable.setData([[
+      // eslint-disable-next-line max-len
+      "There are no code sections that could be analyzed, it is possible you are using a production configuration. To see more on modules and assets switch to a development configuration."
+    ]]);
+    this.assetTable.setData([[
+      "Unable to list specific asset data."
+    ]]);
+  }
+
+  setProductionProblemsWarning() {
+    this.problemsMenu.setLabel(chalk.yellow("Problems (warning)"));
+    this.problems.setContent("Unable to analyze problems.");
   }
 
   setProblems(data) {

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -250,9 +250,10 @@ class Dashboard {
   }
 
   setLog(data) {
-    if (!this.stats.hasErrors()) {
-      this.logText.log(data.value.replace(/[{}]/g, ""));
+    if (this.stats && this.stats.hasErrors()) {
+      return;
     }
+    this.logText.log(data.value.replace(/[{}]/g, ""));
   }
 
   clear() {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -74,6 +74,9 @@ class DashboardPlugin {
       this.socket.on("connect", () => {
         handler = this.socket.emit.bind(this.socket, "message");
       });
+      this.socket.once("mode", args => {
+        this.minimal = args.minimal;
+      });
     }
 
     compiler.apply(
@@ -182,14 +185,16 @@ class DashboardPlugin {
         }
       ]);
 
-      this.observeBundleMetrics(stats, this.inspectpack).subscribe({
-        next: message => handler([message]),
-        error: err => {
-          console.log("Error from inspectpack:", err); // eslint-disable-line no-console
-          this.cleanup();
-        },
-        complete: this.cleanup
-      });
+      if (!this.minimal) {
+        this.observeBundleMetrics(stats, this.inspectpack).subscribe({
+          next: message => handler([message]),
+          error: err => {
+            console.log("Error from inspectpack:", err); // eslint-disable-line no-console
+            this.cleanup();
+          },
+          complete: this.cleanup
+        });
+      }
     });
   }
 

--- a/utils/format-modules.js
+++ b/utils/format-modules.js
@@ -26,7 +26,14 @@ function getModuleName(module) {
       .slice(0, SCOPED_PACKAGE_INDEX)
       .reduce((x, y) => x + y);
   }
-  return module.baseName.split("/")[0];
+  const nameComponents = module.baseName.split("/");
+  if (nameComponents[0] === ".") {
+    // In Webpack 3, the part of the file name we want to display is the
+    // third component when split. In Webpack 2, it's the first.
+    // eslint-disable-next-line no-magic-numbers
+    return nameComponents[2];
+  }
+  return nameComponents[0];
 }
 
 function getModuleNameWithVersion(module) {

--- a/utils/format-modules.js
+++ b/utils/format-modules.js
@@ -26,7 +26,7 @@ function getModuleName(module) {
       .slice(0, SCOPED_PACKAGE_INDEX)
       .reduce((x, y) => x + y);
   }
-  const nameComponents = module.baseName.split("/");
+  const nameComponents = module.baseName.split(path.sep);
   if (nameComponents[0] === ".") {
     // In Webpack 3, the part of the file name we want to display is the
     // third component when split. In Webpack 2, it's the first.


### PR DESCRIPTION
• Fix Webpack 3 module reporting. The path names are different so previously we just saw a single entry. Also ensure module reporting still works for Webpack 2.
• Disable analysis with inspectpack when running in minimal mode
• Show better warnings when inspectpack cannot get more data when Webpack is running in production

Addresses #201 #198 

**Production**
<img width="1002" alt="screen shot 2017-10-04 at 1 02 31 pm" src="https://user-images.githubusercontent.com/1738349/31197277-6ec4f5f8-a905-11e7-9bd2-465c7bd5d45a.png">

**Fixed Webpack 3**
<img width="1002" alt="screen shot 2017-10-04 at 1 20 23 pm" src="https://user-images.githubusercontent.com/1738349/31197717-d0e79690-a906-11e7-9b73-eb73244af906.png">

**Webpack 2**
<img width="1002" alt="screen shot 2017-10-04 at 1 19 46 pm" src="https://user-images.githubusercontent.com/1738349/31197731-dbc62cc0-a906-11e7-9e62-db4232e661b9.png">


cc @ryan-roemer @kenwheeler 