### PR TITLE
Added support for node env provide plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Now you can just run your start script like normal, except now, you are awesome.
 
 ### InspectPack and Node Environments
 
-Webpack Dashboard does additional analysis of individual module sizes, asset sizes and any problems when your bundle is unminified and not in a production environment. The Webpack Plugin automatically adds `pathinfo = true` to your configuration’s output object. Environments are defined through the `DefinePlugin` with `process.env["NODE_ENV"]` being `"production"`. Webpack Dashboard will produce a warning if a production configuration is run.
+Webpack Dashboard does additional analysis of individual module sizes, asset sizes, and any problems when your bundle is unminified and not in a production environment. The Webpack Plugin automatically adds `pathinfo = true` to your configuration’s output object. Environments are defined through the `DefinePlugin` with `process.env["NODE_ENV"]` being `"production"`. Webpack Dashboard will produce a warning if a production configuration is run.
 
 #### Run it
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ You would change that to:
 ```
 Now you can just run your start script like normal, except now, you are awesome. Not that you weren't before. I'm just saying. More so.
 
+### InspectPack and Node Environments
+
+Webpack Dashboard does additional analysis of individual module sizes, asset sizes and any problems when your bundle is unminified and not in a production environment. The Webpack Plugin automatically adds `pathinfo = true` to your configuration’s output object. Environments are defined through the `DefinePlugin` with `process.env["NODE_ENV"]` being `"production"`. Webpack Dashboard will produce a warning if a production configuration is run.
+
 #### Run it
 
 Finally, start your server using whatever command you have set up. Either you have `npm run dev` or `npm start` pointed at `node devServer.js` or something along those lines.

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -67,12 +67,13 @@ class Dashboard {
         operations: this.setOperations.bind(this),
         status: this.setStatus.bind(this),
         stats: this.setStats.bind(this),
+        nodeEnv: this.setNodeEnv.bind(this),
         log: this.setLog.bind(this),
         clear: this.clear.bind(this),
         sizes: _data => {
           if (this.minimal) { return; }
           if (_data.value instanceof Error) {
-            if (_data.value.message === "No code sections found") {
+            if (this.nodeEnv === "production") {
               this.setProductionSizesWarning();
               return;
             }
@@ -84,7 +85,7 @@ class Dashboard {
         problems: _data => {
           if (this.minimal) { return; }
           if (_data.value instanceof Error) {
-            if (_data.value.message === "No code sections found") {
+            if (this.nodeEnv === "production") {
               this.setProductionProblemsWarning();
               return;
             }
@@ -94,7 +95,6 @@ class Dashboard {
           }
         }
       };
-
       return map[data.type](data);
     };
 
@@ -127,6 +127,10 @@ class Dashboard {
 
   setOperations(data) {
     this.operations.setContent(data.value);
+  }
+
+  setNodeEnv(data) {
+    this.nodeEnv = data.value;
   }
 
   setStatus(data) {
@@ -210,7 +214,7 @@ class Dashboard {
     this.assets.setLabel(chalk.yellow("Assets (warning)"));
     this.moduleTable.setData([[
       // eslint-disable-next-line max-len
-      "There are no code sections that could be analyzed, it is possible you are using a production configuration. To see more on modules and assets switch to a development configuration."
+      "It appears you are using a production config. Therefore there are no code sections that could be analyzed. To see more on modules and assets switch to a development configuration."
     ]]);
     this.assetTable.setData([[
       "Unable to list specific asset data."

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -73,10 +73,6 @@ class Dashboard {
         sizes: _data => {
           if (this.minimal) { return; }
           if (_data.value instanceof Error) {
-            if (this.nodeEnv === "production") {
-              this.setProductionSizesWarning();
-              return;
-            }
             this.setSizesError(_data.value);
           } else {
             this.setSizes(_data);
@@ -85,10 +81,6 @@ class Dashboard {
         problems: _data => {
           if (this.minimal) { return; }
           if (_data.value instanceof Error) {
-            if (this.nodeEnv === "production") {
-              this.setProductionProblemsWarning();
-              return;
-            }
             this.setProblemsError(_data.value);
           } else {
             this.setProblems(_data);
@@ -131,6 +123,9 @@ class Dashboard {
 
   setNodeEnv(data) {
     this.nodeEnv = data.value;
+    if (this.nodeEnv === "production") {
+      this.setProductionConfigurationWarning();
+    }
   }
 
   setStatus(data) {
@@ -209,7 +204,7 @@ class Dashboard {
     this.logText.log(chalk.red(err));
   }
 
-  setProductionSizesWarning() {
+  setProductionConfigurationWarning() {
     this.modulesMenu.setLabel(chalk.yellow("Modules (warning)"));
     this.assets.setLabel(chalk.yellow("Assets (warning)"));
     this.moduleTable.setData([[
@@ -219,9 +214,6 @@ class Dashboard {
     this.assetTable.setData([[
       "Unable to list specific asset data."
     ]]);
-  }
-
-  setProductionProblemsWarning() {
     this.problemsMenu.setLabel(chalk.yellow("Problems (warning)"));
     this.problems.setContent("Unable to analyze problems.");
   }

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -110,6 +110,7 @@ class DashboardPlugin {
       this.watching = true;
       done();
     });
+
     compiler.plugin("run", (c, done) => {
       this.watching = false;
       done();
@@ -117,7 +118,6 @@ class DashboardPlugin {
 
     compiler.plugin("compile", () => {
       timer = Date.now();
-
       handler([
         {
           type: "status",

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -2,7 +2,6 @@
 "use strict";
 
 const _ = require("lodash/fp");
-const { get } = require("lodash");
 const os = require("os");
 const path = require("path");
 const most = require("most");
@@ -70,8 +69,8 @@ class DashboardPlugin {
     // Safely get the node env if specified in the webpack config
     const definePlugin = compiler.options.plugins
       .filter(plugin => plugin.constructor.name === "DefinePlugin")[0];
-    const nodeEnv = JSON.parse(get(definePlugin,
-      ["definitions", "process.env", "NODE_ENV"], "\"development\""));
+    const nodeEnv = JSON.parse(
+      _.getOr("\"development\"")(["definitions", "process.env", "NODE_ENV"])(definePlugin));
 
     if (!handler) {
       handler = noop;

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -193,7 +193,7 @@ class DashboardPlugin {
         }
       ]);
 
-      if (!this.minimal) {
+      if (!this.minimal && nodeEnv !== "production") {
         this.observeBundleMetrics(stats, this.inspectpack).subscribe({
           next: message => handler([message]),
           error: err => {


### PR DESCRIPTION
For electron webpack dashboard we want to visually show differences when running in production and be more specific in webpack dashboard. This will be needed for https://github.com/FormidableLabs/electron-webpack-dashboard/issues/33.

Addresses #197 

* See if the `DefinePlugin` exists and safely traverse the object to see if a `production` `NODE_ENV` variable is set
* Report that value once when the webpack process starts (since it cannot change over the lifetime of the running dashboard instance)

cc @kenwheeler @ryan-roemer 