### PR TITLE
Wait until apply to create inspectpack daemon

### DIFF
--- a/plugin/index.js
+++ b/plugin/index.js
@@ -49,7 +49,6 @@ class DashboardPlugin {
 
     this.cleanup = this.cleanup.bind(this);
 
-    this.inspectpack = InspectpackDaemon.create({ cacheFilename });
     this.watching = false;
   }
 
@@ -57,11 +56,16 @@ class DashboardPlugin {
     if (!this.watching && this.socket) {
       this.handler = null;
       this.socket.close();
-      this.inspectpack.terminate();
+      if (this.inspectpack) {
+        this.inspectpack.terminate();
+      }
     }
   }
 
   apply(compiler) {
+    // Lazily created so plugin can be configured without starting the daemon
+    this.inspectpack = InspectpackDaemon.create({ cacheFilename });
+
     let handler = this.handler;
     let timer;
 


### PR DESCRIPTION
This makes it so the dashboard plugin can be configured without creating the inspectpack daemon.  If the daemon is created in the constructor, the plugin cannot be conditionally applied.  Currently, if the plugin is configured and added as part of a development only config, the process running the production config will never exit.  With the changes here, the plugin can be configured but if it is never applied, the webpack process exits properly.

Fixes #96.
Fixes #125.
