### PR TITLE
fix issue when bundle don't have metrics at all

### DIFF
--- a/utils/format-assets.js
+++ b/utils/format-assets.js
@@ -25,7 +25,7 @@ function resolveAssets(tree, bundles) {
         const realBundleMatch = _.find({ path: asset.name })(bundles);
         return realBundleMatch ? {
           name: realBundleMatch.path,
-          size: realBundleMatch.metrics.meta.bundle.minGz,
+          size: realBundleMatch.metrics ? realBundleMatch.metrics.meta.bundle.minGz : 0,
           minGz: true
         } : asset;
       })

--- a/utils/format-modules.js
+++ b/utils/format-modules.js
@@ -72,7 +72,7 @@ function groupModules(bundle) {
       });
     }),
     _.orderBy(_.get("size.minGz"), "desc")
-  )(bundle.metrics.sizes);
+  )(realBundleMatch.metrics ? bundle.metrics.sizes : []);
 }
 
 // Get the sum of all module groups' min+gz size.

--- a/utils/format-modules.js
+++ b/utils/format-modules.js
@@ -72,7 +72,7 @@ function groupModules(bundle) {
       });
     }),
     _.orderBy(_.get("size.minGz"), "desc")
-  )(realBundleMatch.metrics ? bundle.metrics.sizes : []);
+  )(bundle.metrics ? bundle.metrics.sizes : []);
 }
 
 // Get the sum of all module groups' min+gz size.


### PR DESCRIPTION
this issue can be found in electron based project when using electron API in `renderer`

```
yarn run v1.2.1
$ webpack-dashboard -- node .electron-vue/dev-runner.js
TypeError: Cannot read property 'meta' of undefined
    at assets.filter.map.asset (/home/wildan/Projects/Sensorfied/f.i.d.e/node_modules/webpack-dashboard/utils/format-assets.js:28:41)
    at Array.map (<anonymous>)
    at _.flatMap.assets (/home/wildan/Projects/Sensorfied/f.i.d.e/node_modules/webpack-dashboard/utils/format-assets.js:24:8)
    at l (/home/wildan/Projects/Sensorfied/f.i.d.e/node_modules/lodash/lodash.min.js:6:443)
    at uu (/home/wildan/Projects/Sensorfied/f.i.d.e/node_modules/lodash/lodash.min.js:67:252)
    at On.flatMap (/home/wildan/Projects/Sensorfied/f.i.d.e/node_modules/lodash/lodash.min.js:99:101)
    at l (/home/wildan/Projects/Sensorfied/f.i.d.e/node_modules/lodash/lodash.min.js:50:137)
    at resolveAssets (/home/wildan/Projects/Sensorfied/f.i.d.e/node_modules/webpack-dashboard/utils/format-assets.js:32:4)
    at printAssets (/home/wildan/Projects/Sensorfied/f.i.d.e/node_modules/webpack-dashboard/utils/format-assets.js:36:18)
    at formatAssets (/home/wildan/Projects/Sensorfied/f.i.d.e/node_modules/webpack-dashboard/utils/format-assets.js:55:10)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

encounter this bug when using vue-electron template project