### PR TITLE
Only log stdout when there are errors are no warnings

### DIFF
--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -165,7 +165,9 @@ class Dashboard {
       this.status.setContent("{red-fg}{bold}Failed{/}");
     }
 
-    this.logText.log(formatOutput(stats));
+    if (!stats.hasWarnings() || stats.hasErrors()) {
+      this.logText.log(formatOutput(stats));
+    }
 
     if (!this.minimal) {
       this.modulesMenu.setLabel(chalk.yellow("Modules (loading...)"));


### PR DESCRIPTION
I'm not sure if this is a breaking change, but when I added webpack-dashboard, I was having issues where warnings would be logged twice. This adds a check when you're displaying the stats to check to make sure that you don't have any warnings so that it doesn't  duplicate those logs. Here's the before and after screenshots:

**Before**

![screen shot 2018-05-17 at 5 20 53 pm](https://user-images.githubusercontent.com/2652762/40187930-0ba025ec-59f9-11e8-8923-5c15c6c78820.png)

**After**
![screen shot 2018-05-17 at 5 17 05 pm](https://user-images.githubusercontent.com/2652762/40187940-1058cff8-59f9-11e8-9c27-7fa01fbdc833.png)

Behavior for actual errors, standard logs, and successful builds remains the same