### PR TITLE
Simplify contribution process. Integrate inspectpack fixtures.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,0 @@
----
-extends:
-	- formidable/configurations/es6-node
-rules:
-  func-style: off
-  arrow-parens: [error, as-needed]

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "extends": "formidable/configurations/es6-node",
+  "rules": {
+    "func-style": "off",
+    "arrow-parens": ["error", "as-needed"]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
 # dependencies
-node_modules
+/node_modules/
 
 # misc
 .DS_Store
 npm-debug.log*
 .nyc_output
 .coverage
-.lankrc*
 yarn-error.log
 package-lock.json
+dist-*
+.vscode

--- a/README.md
+++ b/README.md
@@ -94,6 +94,33 @@ Webpack Dashboard works in Terminal, iTerm 2, and Hyper. For mouse events, like 
 
 *Note: you can also just pass a function in as an argument, which then becomes the handler, i.e. `new DashboardPlugin(dashboard.setData)`*
 
+### Local Development
+
+We've standardized our local development process for `webpack-dashboard` on using `yarn`. We recommend using `yarn 1.10.x+`, as these versions include the `integrity` checksum. The checksum helps to verify the integrity of an installed package before its code is executed. 🚀
+
+To run this repo locally against our provided examples, take the usual steps.
+
+```sh
+yarn
+yarn dev
+```
+
+We re-use a small handful of the fixtures from [`inspectpack`](https://github.com/FormidableLabs/inspectpack) so that you can work locally on the dashboard while simulating common `node_modules` dependency issues you might face in the wild. These live in `/examples`.
+
+To change the example you're working against, simply alter the `EXAMPLE` env variable in the `dev` script in `package.json` to match the scenario you want to run in `/examples`. For example, if you want to run the `tree-shaking` example, change the `dev` script from this:
+
+```sh
+cross-env EXAMPLE=duplicates-esm node bin/webpack-dashboard.js -- webpack-cli --config examples/config/webpack.config.js --watch
+```
+
+to this:
+
+```sh
+cross-env EXAMPLE=tree-shaking node bin/webpack-dashboard.js -- webpack-cli --config examples/config/webpack.config.js --watch
+```
+
+Then just run `yarn dev` to get up and running. PRs are very much appreciated!
+
 #### Credits
 
 Module output deeply inspired by: [https://github.com/robertknight/webpack-bundle-size-analyzer](https://github.com/robertknight/webpack-bundle-size-analyzer)

--- a/bin/webpack-dashboard.js
+++ b/bin/webpack-dashboard.js
@@ -13,7 +13,7 @@ const program = new commander.Command("webpack-dashboard");
 const pkg = require("../package.json");
 
 // Wrap up side effects in a script.
-const main = module.exports = opts => { // eslint-disable-line max-statements
+const main = module.exports = opts => { // eslint-disable-line max-statements, complexity
   opts = opts || {};
   const argv = typeof opts.argv === "undefined" ? process.argv : opts.argv;
 

--- a/examples/.eslintrc.json
+++ b/examples/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "sourceType": "module"
+  }
+}

--- a/examples/config/webpack.config.js
+++ b/examples/config/webpack.config.js
@@ -1,0 +1,34 @@
+const { resolve } = require("path");
+const { StatsWriterPlugin } = require("webpack-stats-plugin");
+const { DuplicatesPlugin } = require("inspectpack/plugin");
+const Dashboard = require("../../plugin");
+
+// Specify the directory of the example we're working with
+const cwd = `${process.cwd()}/examples/${process.env.EXAMPLE}`;
+if (!process.env.EXAMPLE) {
+  throw new Error("EXAMPLE is required");
+}
+
+module.exports = {
+  mode: "development",
+  devtool: false,
+  context: resolve(cwd),
+  entry: {
+    bundle: "./src/index.js"
+  },
+  output: {
+    path: resolve(cwd, "dist-development-4"),
+    pathinfo: true,
+    filename: "[name].js"
+  },
+  plugins: [
+    new StatsWriterPlugin({
+      fields: ["assets", "modules"]
+    }),
+    new DuplicatesPlugin({
+      verbose: true,
+      emitErrors: false
+    }),
+    new Dashboard()
+  ]
+};

--- a/examples/duplicates-esm/node_modules/foo/index.js
+++ b/examples/duplicates-esm/node_modules/foo/index.js
@@ -1,0 +1,3 @@
+export const foo = function () {
+  return "foo";
+};

--- a/examples/duplicates-esm/node_modules/foo/package.json
+++ b/examples/duplicates-esm/node_modules/foo/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "foo",
+  "version": "1.1.1",
+  "description": "DUMMY MODULE",
+  "main": "index.js"
+}

--- a/examples/duplicates-esm/node_modules/uses-foo/index.js
+++ b/examples/duplicates-esm/node_modules/uses-foo/index.js
@@ -1,0 +1,5 @@
+import { foo } from "foo";
+
+export const usesFoo = function () {
+  return foo();
+};

--- a/examples/duplicates-esm/node_modules/uses-foo/node_modules/foo/index.js
+++ b/examples/duplicates-esm/node_modules/uses-foo/node_modules/foo/index.js
@@ -1,0 +1,3 @@
+export const foo = function () {
+  return "foo";
+};

--- a/examples/duplicates-esm/node_modules/uses-foo/node_modules/foo/package.json
+++ b/examples/duplicates-esm/node_modules/uses-foo/node_modules/foo/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "foo",
+  "version": "2.2.2",
+  "description": "DUMMY MODULE",
+  "main": "index.js"
+}

--- a/examples/duplicates-esm/node_modules/uses-foo/package.json
+++ b/examples/duplicates-esm/node_modules/uses-foo/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "uses-foo",
+  "version": "1.1.1",
+  "description": "DUMMY MODULE",
+  "main": "index.js",
+  "dependencies": {
+    "foo": "^2.2.0"
+  }
+}

--- a/examples/duplicates-esm/package.json
+++ b/examples/duplicates-esm/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "duplicates-esm",
+  "version": "1.2.3",
+  "description": "DUMMY APP",
+  "main": "src/index.js",
+  "dependencies": {
+    "foo": "^1.0.0",
+    "uses-foo": "^1.0.9"
+  }
+}

--- a/examples/duplicates-esm/src/index.js
+++ b/examples/duplicates-esm/src/index.js
@@ -1,0 +1,6 @@
+/* eslint-disable no-console*/
+import { foo } from "foo";
+import { usesFoo } from "uses-foo";
+
+console.log("foo", foo());
+console.log("usesFoo", usesFoo());

--- a/examples/simple/package.json
+++ b/examples/simple/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "simple",
+  "version": "1.2.3",
+  "description": "DUMMY APP",
+  "main": "src/index.js"
+}

--- a/examples/simple/src/index.js
+++ b/examples/simple/src/index.js
@@ -1,0 +1,6 @@
+
+/* eslint-disable no-console*/
+
+const hello = () => "hello world";
+
+console.log(hello());

--- a/examples/tree-shaking/node_modules/foo/green.js
+++ b/examples/tree-shaking/node_modules/foo/green.js
@@ -1,0 +1,3 @@
+export const green = function () {
+  return "green";
+};

--- a/examples/tree-shaking/node_modules/foo/index.js
+++ b/examples/tree-shaking/node_modules/foo/index.js
@@ -1,0 +1,9 @@
+export { green } from "./green";
+
+export const red = function () {
+  return "red";
+};
+
+export const blue = function () {
+  return "blue";
+};

--- a/examples/tree-shaking/node_modules/foo/package.json
+++ b/examples/tree-shaking/node_modules/foo/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "foo",
+  "version": "1.1.1",
+  "description": "DUMMY MODULE",
+  "main": "index.js",
+  "module": "index.js",
+  "sideEffects": false
+}

--- a/examples/tree-shaking/node_modules/uses-foo/index.js
+++ b/examples/tree-shaking/node_modules/uses-foo/index.js
@@ -1,0 +1,5 @@
+import { red } from "foo";
+
+export const usesRed = function () {
+  return red();
+};

--- a/examples/tree-shaking/node_modules/uses-foo/node_modules/foo/green.js
+++ b/examples/tree-shaking/node_modules/uses-foo/node_modules/foo/green.js
@@ -1,0 +1,3 @@
+export const green = function () {
+  return "green";
+};

--- a/examples/tree-shaking/node_modules/uses-foo/node_modules/foo/index.js
+++ b/examples/tree-shaking/node_modules/uses-foo/node_modules/foo/index.js
@@ -1,0 +1,9 @@
+export { green } from "./green";
+
+export const red = function () {
+  return "red";
+};
+
+export const blue = function () {
+  return "blue";
+};

--- a/examples/tree-shaking/node_modules/uses-foo/node_modules/foo/package.json
+++ b/examples/tree-shaking/node_modules/uses-foo/node_modules/foo/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "foo",
+  "version": "2.2.2",
+  "description": "DUMMY MODULE",
+  "main": "index.js",
+  "module": "index.js",
+  "sideEffects": false
+}

--- a/examples/tree-shaking/node_modules/uses-foo/package.json
+++ b/examples/tree-shaking/node_modules/uses-foo/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "uses-foo",
+  "version": "1.1.1",
+  "description": "DUMMY MODULE",
+  "main": "index.js",
+  "module": "index.js",
+  "dependencies": {
+    "foo": "^2.2.0"
+  },
+  "sideEffects": false
+}

--- a/examples/tree-shaking/package.json
+++ b/examples/tree-shaking/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "tree-shaking",
+  "version": "1.2.3",
+  "description": "DUMMY APP",
+  "main": "src/index.js",
+  "dependencies": {
+    "foo": "^1.0.0",
+    "uses-foo": "^1.0.9"
+  }
+}

--- a/examples/tree-shaking/src/index.js
+++ b/examples/tree-shaking/src/index.js
@@ -1,0 +1,7 @@
+/* eslint-disable no-console*/
+
+import { red } from "foo";
+import { usesRed } from "uses-foo";
+
+console.log("red", red());
+console.log("usesRed", usesRed());

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test-cov": "nyc mocha 'test/**/*.spec.js'",
     "lint": "eslint .",
     "check": "npm run lint && npm run test",
-    "check-ci": "npm run lint && npm run test-cov"
+    "check-ci": "npm run lint && npm run test-cov",
+    "dev": "cross-env EXAMPLE=duplicates-esm node bin/webpack-dashboard.js -- webpack-cli --config examples/config/webpack.config.js --watch"
   },
   "repository": {
     "type": "git",
@@ -47,6 +48,7 @@
   "devDependencies": {
     "babel-eslint": "^8.2.3",
     "chai": "^4.1.2",
+    "cross-env": "^5.2.0",
     "eslint": "^4.19.1",
     "eslint-config-formidable": "^4.0.0",
     "eslint-plugin-filenames": "^1.1.0",
@@ -57,6 +59,7 @@
     "sinon": "^5.0.7",
     "sinon-chai": "^3.0.0",
     "webpack": "^4.8.3",
-    "webpack-cli": "^2.1.3"
+    "webpack-cli": "^2.1.3",
+    "webpack-stats-plugin": "^0.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1906,6 +1906,14 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"
+  integrity sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==
+  dependencies:
+    cross-spawn "^6.0.5"
+    is-windows "^1.0.0"
+
 cross-spawn@^4:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
@@ -3564,7 +3572,7 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-windows@^1.0.1, is-windows@^1.0.2:
+is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
@@ -6421,6 +6429,11 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0:
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack-stats-plugin@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-stats-plugin/-/webpack-stats-plugin-0.2.1.tgz#1f5bac13fc25d62cbb5fd0ff646757dc802b8595"
+  integrity sha512-OYMZLpZrK/qLA79NE4kC4DCt85h/5ipvWJcsefKe9MMw0qU4/ck/IJg+4OmWA+5EfrZZpHXDq92IptfYDWVfkw==
 
 webpack@^4.8.3:
   version "4.8.3"


### PR DESCRIPTION
This PR adds some niceties to make the contributing process for `webpack-dashboard` a bit easier. Specifically, we introduce a `yarn dev` command that allows a user to immediately run one of the example fixtures in `/examples`. The example being run is controlled by `process.env.EXAMPLE`, which can be altered in `package.json`.

I need to give @mhink credit for the implementation idea here. He suggested adding some sort of flag to the CLI to indicate that we want to run the example project. When that flag (supplied as `-e, --example`) gets passed, we spin up a separate child process to run one of the fixtures specified in `/examples` (based on the value of `process.env.EXAMPLE`). This will _only_ work currently if no other command is passed to `webpack-dashboard` and you're running `-e` from a clone of this repository (since `/examples` will not get published to `npm`).

Lastly, I made the decision to just duplicate a few of the `inspectpack` fixtures here rather than try to bring them in as a Git dependency. Attempting to access those fixtures deep in `node_modules` was proving to be a bit brittle, and the heavy use of `env` variables made me a bit worried about having full dev support for Windows users. So I stripped the config down to only run against latest `webpack`, and use `cross-env` to support Windows environments for our single environment variable `EXAMPLE`.

Would love thoughts, opinions, and feelings about this approach. Do you feel this makes it easier to get started working on `webpack-dashboard`?