### PR TITLE
Migrate to using neo-blessed as underlying blessed renderer.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "formidable/configurations/es6-node",
+  "extends": ["formidable/configurations/es6-node", "plugin:prettier/recommended"],
   "rules": {
     "func-style": "off",
     "arrow-parens": ["error", "as-needed"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "6"
   - "8"
   - "10"
 

--- a/README.md
+++ b/README.md
@@ -18,26 +18,25 @@ That's cool, but it's mostly noise and scrolly and not super helpful. This plugi
 
 ### Use
 
+**`webpack-dashboard@^2.1.1` requires Node 8 or above.** Previous versions support down to Node 6.
+
 First, import the plugin and add it to your webpack config, or apply it to your compiler:
 
 ```js
 // Import the plugin:
-var DashboardPlugin = require('webpack-dashboard/plugin');
+var DashboardPlugin = require("webpack-dashboard/plugin");
 
 // If you aren't using express, add it to your webpack configs plugins section:
-plugins: [
-    new DashboardPlugin()
-]
+plugins: [new DashboardPlugin()];
 
 // If you are using an express based dev server, add it with compiler.apply
 compiler.apply(new DashboardPlugin());
 ```
+
 If using a custom port, the port number must be included in the options object here, as well as passed using the -p flag in the call to webpack-dashboard. See how below:
 
 ```js
-plugins: [
-    new DashboardPlugin({ port: 3001 })
-]
+plugins: [new DashboardPlugin({ port: 3001 })];
 ```
 
 In the latest version, you can either run your app, and run `webpack-dashboard` independently (by installing with `npm install webpack-dashboard -g`) or run webpack-dashboard from your `package.json`. So if your dev server start script previously looked like:
@@ -55,6 +54,7 @@ You would change that to:
     "dev": "webpack-dashboard -- node index.js"
 }
 ```
+
 Now you can just run your start script like normal, except now, you are awesome. Not that you weren't before. I'm just saying. More so.
 
 ### Run it
@@ -64,8 +64,9 @@ Finally, start your server using whatever command you have set up. Either you ha
 Then, sit back and pretend you're an astronaut.
 
 ### Supported Operating Systems and Terminals
+
 **macOS →**
-Webpack Dashboard works in Terminal, iTerm 2, and Hyper. For mouse events, like scrolling, in Terminal you will need to ensure *View → Enable Mouse Reporting* is enabled. This is supported in macOS El Capitan, Sierra, and High Sierra. In iTerm 2, to select full rows of text hold the <kbd>⌥ Opt</kbd> key. To select a block of text hold the <kbd>⌥ Opt</kbd> + <kbd>⌘ Cmd</kbd> key combination.
+Webpack Dashboard works in Terminal, iTerm 2, and Hyper. For mouse events, like scrolling, in Terminal you will need to ensure _View → Enable Mouse Reporting_ is enabled. This is supported in macOS El Capitan, Sierra, and High Sierra. In iTerm 2, to select full rows of text hold the <kbd>⌥ Opt</kbd> key. To select a block of text hold the <kbd>⌥ Opt</kbd> + <kbd>⌘ Cmd</kbd> key combination.
 
 **Windows 10 →** Webpack Dashboard works in Command Prompt, PowerShell, and Linux Subsystem for Windows. Mouse events are not supported at this time, as discussed further in the documentation of the underlying terminal library we use [Blessed](https://github.com/chjj/blessed#windows-compatibility). The main log can be scrolled using the <kbd>↑</kbd>, <kbd>↓</kbd>, <kbd>Page Up</kbd>, and <kbd>Page Down</kbd> keys.
 
@@ -74,25 +75,27 @@ Webpack Dashboard works in Terminal, iTerm 2, and Hyper. For mouse events, like 
 ### API
 
 #### webpack-dashboard (CLI)
+
 ##### Options
 
- - `-c, --color [color]` - Custom ANSI color for your dashboard
- - `-m, --minimal` - Runs the dashboard in minimal mode
- - `-t, --title [title]` - Set title of terminal window
- - `-p, --port [port]` - Custom port for socket communication server
+- `-c, --color [color]` - Custom ANSI color for your dashboard
+- `-m, --minimal` - Runs the dashboard in minimal mode
+- `-t, --title [title]` - Set title of terminal window
+- `-p, --port [port]` - Custom port for socket communication server
 
 ##### Arguments
 
 `[command]` - The command you want to run, i.e. `webpack-dashboard -- node index.js`
 
 #### Webpack plugin
+
 #### Options
 
- - `host` - Custom host for connection the socket client
- - `port` - Custom port for connecting the socket client
- - `handler` - Plugin handler method, i.e. `dashboard.setData`
+- `host` - Custom host for connection the socket client
+- `port` - Custom port for connecting the socket client
+- `handler` - Plugin handler method, i.e. `dashboard.setData`
 
-*Note: you can also just pass a function in as an argument, which then becomes the handler, i.e. `new DashboardPlugin(dashboard.setData)`*
+_Note: you can also just pass a function in as an argument, which then becomes the handler, i.e. `new DashboardPlugin(dashboard.setData)`_
 
 ### Local Development
 

--- a/bin/webpack-dashboard.js
+++ b/bin/webpack-dashboard.js
@@ -13,7 +13,8 @@ const program = new commander.Command("webpack-dashboard");
 const pkg = require("../package.json");
 
 // Wrap up side effects in a script.
-const main = module.exports = opts => { // eslint-disable-line max-statements, complexity
+// eslint-disable-next-line max-statements, complexity
+const main = (module.exports = opts => {
   opts = opts || {};
   const argv = typeof opts.argv === "undefined" ? process.argv : opts.argv;
 
@@ -72,17 +73,21 @@ const main = module.exports = opts => { // eslint-disable-line max-statements, c
     });
 
     child.stdout.on("data", data => {
-      dashboard.setData([{
-        type: "log",
-        value: data.toString("utf8")
-      }]);
+      dashboard.setData([
+        {
+          type: "log",
+          value: data.toString("utf8")
+        }
+      ]);
     });
 
     child.stderr.on("data", data => {
-      dashboard.setData([{
-        type: "log",
-        value: data.toString("utf8")
-      }]);
+      dashboard.setData([
+        {
+          type: "log",
+          value: data.toString("utf8")
+        }
+      ]);
     });
 
     process.on("exit", () => {
@@ -95,7 +100,7 @@ const main = module.exports = opts => { // eslint-disable-line max-statements, c
       });
     });
   }
-};
+});
 
 if (require.main === module) {
   main();

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const chalk = require("chalk");
-const blessed = require("blessed");
+const blessed = require("neo-blessed");
 
 const { formatOutput } = require("../utils/format-output");
 const { formatModules } = require("../utils/format-modules");
@@ -94,13 +94,12 @@ class Dashboard {
 
   setData(dataArray) {
     dataArray
-      .map(
-        data =>
-          data.error
-            ? Object.assign({}, data, {
+      .map(data =>
+        data.error
+          ? Object.assign({}, data, {
               value: deserializeError(data.value)
             })
-            : data
+          : data
       )
       .forEach(data => {
         this.actionForMessageType[data.type](data);
@@ -133,14 +132,14 @@ class Dashboard {
     let content;
 
     switch (data.value) {
-    case "Success":
-      content = `{green-fg}{bold}${data.value}{/}`;
-      break;
-    case "Failed":
-      content = `{red-fg}{bold}${data.value}{/}`;
-      break;
-    default:
-      content = `{bold}${data.value}{/}`;
+      case "Success":
+        content = `{green-fg}{bold}${data.value}{/}`;
+        break;
+      case "Failed":
+        content = `{red-fg}{bold}${data.value}{/}`;
+        break;
+      default:
+        content = `{bold}${data.value}{/}`;
     }
     this.status.setContent(content);
   }
@@ -497,8 +496,8 @@ class Dashboard {
       tags: true,
       padding: this.minimal
         ? {
-          left: 1
-        }
+            left: 1
+          }
         : 1,
       width: this.minimal ? "33%" : "100%",
       height: this.minimal ? "100%" : "34%",

--- a/examples/simple/src/index.js
+++ b/examples/simple/src/index.js
@@ -1,4 +1,3 @@
-
 /* eslint-disable no-console*/
 
 const hello = () => "hello world";

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "test": "mocha 'test/**/*.spec.js'",
     "test-cov": "nyc mocha 'test/**/*.spec.js'",
     "lint": "eslint .",
-    "check": "npm run lint && npm run test && npm run check-ts",
-    "check-ci": "npm run lint && npm run test-cov && npm run check-ts",
+    "check": "npm run format-check && npm run lint && npm run test && npm run check-ts",
+    "check-ci": "npm run format-check && npm run lint && npm run test-cov && npm run check-ts",
     "check-ts": "tsc index.d.ts --noEmit",
-    "dev": "cross-env EXAMPLE=duplicates-esm node bin/webpack-dashboard.js -- webpack-cli --config examples/config/webpack.config.js --watch"
+    "dev": "cross-env EXAMPLE=duplicates-esm node bin/webpack-dashboard.js -- webpack-cli --config examples/config/webpack.config.js --watch",
+    "format": "prettier --write './{bin,examples,plugin,test,utils}/**/*.js'",
+    "format-check": "prettier --list-different './{bin,examples,plugin,test,utils}/**/*.js'"
   },
   "repository": {
     "type": "git",
@@ -37,13 +39,13 @@
     "webpack": "*"
   },
   "dependencies": {
-    "blessed": "^0.1.81",
     "commander": "^2.15.1",
     "cross-spawn": "^6.0.5",
     "filesize": "^3.6.1",
     "handlebars": "^4.0.11",
     "inspectpack": "^4.0.0",
     "most": "^1.7.3",
+    "neo-blessed": "^0.2.0",
     "socket.io": "^2.1.1",
     "socket.io-client": "^2.1.1"
   },
@@ -53,11 +55,14 @@
     "cross-env": "^5.2.0",
     "eslint": "^4.19.1",
     "eslint-config-formidable": "^4.0.0",
+    "eslint-config-prettier": "^4.0.0",
     "eslint-plugin-filenames": "^1.1.0",
     "eslint-plugin-import": "^2.12.0",
+    "eslint-plugin-prettier": "^3.0.1",
     "eslint-plugin-promise": "^3.7.0",
     "mocha": "^5.2.0",
     "nyc": "^11.8.0",
+    "prettier": "^1.16.4",
     "sinon": "^5.0.7",
     "sinon-chai": "^3.0.0",
     "typescript": "^3.2.4",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,4 +1,0 @@
----
-extends:
-	- formidable/configurations/es6-node-test
-

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["formidable/configurations/es6-node-test", "plugin:prettier/recommended"]
+}

--- a/test/base.spec.js
+++ b/test/base.spec.js
@@ -10,11 +10,11 @@
  */
 const sinon = require("sinon");
 
-const blessed = require("blessed");
+const blessed = require("neo-blessed");
 
-const base = module.exports = {
+const base = (module.exports = {
   sandbox: null
-};
+});
 
 beforeEach(() => {
   base.sandbox = sinon.createSandbox({

--- a/test/bin/webpack-dashboard.spec.js
+++ b/test/bin/webpack-dashboard.spec.js
@@ -6,11 +6,13 @@ const cli = require("../../bin/webpack-dashboard");
 
 describe("bin/webpack-dashboard", () => {
   it("can invoke the dashboard cli", () => {
-    expect(() => cli({
-      argv: [],
-      server: {
-        on: base.sandbox.spy()
-      }
-    })).to.not.throw();
+    expect(() =>
+      cli({
+        argv: [],
+        server: {
+          on: base.sandbox.spy()
+        }
+      })
+    ).to.not.throw();
   });
 });

--- a/test/dashboard/index.spec.js
+++ b/test/dashboard/index.spec.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const chalk = require("chalk");
-const blessed = require("blessed");
+const blessed = require("neo-blessed");
 
 const base = require("../base.spec");
 const Dashboard = require("../../dashboard");
@@ -50,13 +50,16 @@ describe("dashboard", () => {
     });
 
     describe("setData", () => {
-      const dataArray = [{
-        type: "progress",
-        value: 0.57
-      }, {
-        type: "operations",
-        value: "IDLE"
-      }];
+      const dataArray = [
+        {
+          type: "progress",
+          value: 0.57
+        },
+        {
+          type: "operations",
+          value: "IDLE"
+        }
+      ];
 
       it("can setData", () => {
         expect(() => dashboard.setData(dataArray)).to.not.throw;
@@ -85,8 +88,9 @@ describe("dashboard", () => {
         expect(() => dashboard.setStatus(data)).to.not.throw;
 
         dashboard.setStatus(data);
-        expect(dashboard.status.setContent)
-          .to.have.been.calledWith(`{green-fg}{bold}${data.value}{/}`);
+        expect(dashboard.status.setContent).to.have.been.calledWith(
+          `{green-fg}{bold}${data.value}{/}`
+        );
       });
 
       it("should display a failed status on build failure", () => {
@@ -94,8 +98,9 @@ describe("dashboard", () => {
         expect(() => dashboard.setStatus(data)).to.not.throw;
 
         dashboard.setStatus(data);
-        expect(dashboard.status.setContent)
-          .to.have.been.calledWith(`{red-fg}{bold}${data.value}{/}`);
+        expect(dashboard.status.setContent).to.have.been.calledWith(
+          `{red-fg}{bold}${data.value}{/}`
+        );
       });
 
       it("should display any other status string without coloring", () => {
@@ -103,8 +108,7 @@ describe("dashboard", () => {
         expect(() => dashboard.setStatus(data)).to.not.throw;
 
         dashboard.setStatus(data);
-        expect(dashboard.status.setContent)
-          .to.have.been.calledWith(`{bold}${data.value}{/}`);
+        expect(dashboard.status.setContent).to.have.been.calledWith(`{bold}${data.value}{/}`);
       });
     });
 
@@ -147,12 +151,15 @@ describe("dashboard", () => {
 
         dashboard.setStats(data);
         expect(dashboard.logText.log).to.have.been.called;
-        expect(dashboard.modulesMenu.setLabel)
-          .to.have.been.calledWith(chalk.yellow("Modules (loading...)"));
-        expect(dashboard.assets.setLabel)
-          .to.have.been.calledWith(chalk.yellow("Assets (loading...)"));
-        expect(dashboard.problemsMenu.setLabel)
-          .to.have.been.calledWith(chalk.yellow("Problems (loading...)"));
+        expect(dashboard.modulesMenu.setLabel).to.have.been.calledWith(
+          chalk.yellow("Modules (loading...)")
+        );
+        expect(dashboard.assets.setLabel).to.have.been.calledWith(
+          chalk.yellow("Assets (loading...)")
+        );
+        expect(dashboard.problemsMenu.setLabel).to.have.been.calledWith(
+          chalk.yellow("Problems (loading...)")
+        );
       });
 
       it("should display stats errors if present", () => {
@@ -160,8 +167,7 @@ describe("dashboard", () => {
         expect(() => dashboard.setStats(data)).not.to.throw;
 
         dashboard.setStats(data);
-        expect(dashboard.status.setContent)
-          .to.have.been.calledWith("{red-fg}{bold}Failed{/}");
+        expect(dashboard.status.setContent).to.have.been.calledWith("{red-fg}{bold}Failed{/}");
       });
     });
 
@@ -173,13 +179,15 @@ describe("dashboard", () => {
               meta: {
                 full: 456
               },
-              files: [{
-                size: {
-                  full: 123
-                },
-                fileName: "test.js",
-                baseName: "/home/bar/test.js"
-              }]
+              files: [
+                {
+                  size: {
+                    full: 123
+                  },
+                  fileName: "test.js",
+                  baseName: "/home/bar/test.js"
+                }
+              ]
             },
             bar: {
               meta: {
@@ -206,8 +214,9 @@ describe("dashboard", () => {
         expect(dashboard.assetTable.setData).to.have.been.calledWith(formattedData);
         expect(dashboard.modulesMenu.setLabel).to.have.been.calledWith("Modules");
         expect(dashboard.modulesMenu.setItems).to.have.been.called;
-        expect(dashboard.modulesMenu.selectTab)
-          .to.have.been.calledWith(dashboard.modulesMenu.selected);
+        expect(dashboard.modulesMenu.selectTab).to.have.been.calledWith(
+          dashboard.modulesMenu.selected
+        );
         expect(dashboard.screen.render).to.have.been.called;
       });
 
@@ -227,11 +236,13 @@ describe("dashboard", () => {
         expect(() => dashboard.setSizesError(err)).to.not.throw;
 
         dashboard.setSizesError(err);
-        expect(dashboard.modulesMenu.setLabel)
-          .to.have.been.calledWith(chalk.red("Modules (error)"));
+        expect(dashboard.modulesMenu.setLabel).to.have.been.calledWith(
+          chalk.red("Modules (error)")
+        );
         expect(dashboard.assets.setLabel).to.have.been.calledWith(chalk.red("Assets (error)"));
-        expect(dashboard.logText.log)
-          .to.have.been.calledWith(chalk.red("Could not load module/asset sizes."));
+        expect(dashboard.logText.log).to.have.been.calledWith(
+          chalk.red("Could not load module/asset sizes.")
+        );
         expect(dashboard.logText.log).to.have.been.calledWith(chalk.red(err));
       });
     });
@@ -260,8 +271,9 @@ describe("dashboard", () => {
         dashboard.setProblems(data);
         expect(dashboard.problemsMenu.setLabel).to.have.been.calledWith("Problems");
         expect(dashboard.problemsMenu.setItems).to.have.been.called;
-        expect(dashboard.problemsMenu.selectTab)
-          .to.have.been.calledWith(dashboard.problemsMenu.selected);
+        expect(dashboard.problemsMenu.selectTab).to.have.been.calledWith(
+          dashboard.problemsMenu.selected
+        );
         expect(dashboard.screen.render).to.have.been.called;
       });
 
@@ -282,10 +294,12 @@ describe("dashboard", () => {
         expect(() => dashboard.setProblemsError(err)).to.not.throw;
 
         dashboard.setProblemsError(err);
-        expect(dashboard.problemsMenu.setLabel)
-          .to.have.been.calledWith(chalk.red("Problems (error)"));
-        expect(dashboard.logText.log)
-          .to.have.been.calledWith(chalk.red("Could not analyze bundle problems."));
+        expect(dashboard.problemsMenu.setLabel).to.have.been.calledWith(
+          chalk.red("Problems (error)")
+        );
+        expect(dashboard.logText.log).to.have.been.calledWith(
+          chalk.red("Could not analyze bundle problems.")
+        );
         expect(dashboard.logText.log).to.have.been.calledWith(chalk.red(err.stack));
       });
     });

--- a/test/utils/format-versions.spec.js
+++ b/test/utils/format-versions.spec.js
@@ -10,12 +10,7 @@ describe("format-versions", () => {
           "1.1.1": [
             {
               skews: {
-                parts: [
-                  { name: "foo-dep",
-                    range: "^1.0.0" },
-                  { name: "bar",
-                    range: "^3.0.2" }
-                ]
+                parts: [{ name: "foo-dep", range: "^1.0.0" }, { name: "bar", range: "^3.0.2" }]
               }
             }
           ]
@@ -24,9 +19,9 @@ describe("format-versions", () => {
     };
 
     it("should return a handlebar compile template", () => {
-      const result
+      const result =
         // eslint-disable-next-line max-len
-        = "{yellow-fg}{underline}Version skews{/}\n\n{yellow-fg}{bold}foo{/}\n  {green-fg}1.1.1{/}\n    {cyan-fg}foo-dep{/}@^1.0.0 -> {cyan-fg}bar{/}@^3.0.2\n";
+        "{yellow-fg}{underline}Version skews{/}\n\n{yellow-fg}{bold}foo{/}\n  {green-fg}1.1.1{/}\n    {cyan-fg}foo-dep{/}@^1.0.0 -> {cyan-fg}bar{/}@^3.0.2\n";
       expect(formatVersions(data)).to.equal(result);
     });
   });

--- a/utils/format-assets.js
+++ b/utils/format-assets.js
@@ -29,7 +29,4 @@ function formatAssets(assets) {
   return _printAssets(assetsList);
 }
 
-module.exports = { formatAssets,
-  _getAssetSize,
-  _getTotalSize,
-  _printAssets };
+module.exports = { formatAssets, _getAssetSize, _getTotalSize, _printAssets };

--- a/utils/format-duplicates.js
+++ b/utils/format-duplicates.js
@@ -6,7 +6,7 @@
 const filesize = require("filesize");
 const Handlebars = require("handlebars");
 
-Handlebars.registerHelper("filesize", function (options) {
+Handlebars.registerHelper("filesize", function(options) {
   // eslint-disable-next-line no-invalid-this
   return filesize(options.fn(this));
 });
@@ -23,7 +23,8 @@ const template = Handlebars.compile(
 Extra duplicate files (unique): {{meta.extraFiles.num}}
 Extra duplicate sources (non-unique): {{meta.extraSources.num}}
 Wasted duplicate bytes (non-unique): {{#filesize}}{{meta.extraSources.bytes}}{{/filesize}}
-`);
+`
+);
 /* eslint-enable max-len*/
 
 function formatDuplicates(duplicates) {

--- a/utils/format-modules.js
+++ b/utils/format-modules.js
@@ -31,11 +31,11 @@ function _formatFileName(mod) {
   const isScoped = (parts[lastNmIdx + 1] || "").startsWith("@");
   parts = parts.slice(0, lastNmIdx + (isScoped ? 3 : 2)); // eslint-disable-line no-magic-numbers
 
-  return parts.map(part => part === "node_modules" ? "~" : `{yellow-fg}${part}{/}`).join(sep);
+  return parts.map(part => (part === "node_modules" ? "~" : `{yellow-fg}${part}{/}`)).join(sep);
 }
 
 function _formatPercentage(modSize, assetSize) {
-  const percentage = (modSize / assetSize * PERCENT_MULTIPLIER).toPrecision(PERCENT_PRECISION);
+  const percentage = ((modSize / assetSize) * PERCENT_MULTIPLIER).toPrecision(PERCENT_PRECISION);
 
   return `${percentage}%`;
 }

--- a/utils/format-output.js
+++ b/utils/format-output.js
@@ -58,7 +58,4 @@ function formatOutput(stats) {
   return _lineJoin(output);
 }
 
-module.exports = { formatOutput,
-  _formatMessage,
-  _isLikelyASyntaxError,
-  _lineJoin };
+module.exports = { formatOutput, _formatMessage, _isLikelyASyntaxError, _lineJoin };

--- a/utils/format-versions.js
+++ b/utils/format-versions.js
@@ -3,12 +3,10 @@
 const Handlebars = require("handlebars");
 
 // From inspectpack.
-const pkgNamePath = pkgParts => pkgParts.reduce(
-  (m, part) => `${m}${m ? " -> " : ""}{cyan-fg}${part.name}{/}@${part.range}`,
-  ""
-);
+const pkgNamePath = pkgParts =>
+  pkgParts.reduce((m, part) => `${m}${m ? " -> " : ""}{cyan-fg}${part.name}{/}@${part.range}`, "");
 
-Handlebars.registerHelper("skew", function (options) {
+Handlebars.registerHelper("skew", function(options) {
   // eslint-disable-next-line no-invalid-this
   return pkgNamePath(options.fn(this));
 });
@@ -27,7 +25,8 @@ const template = Handlebars.compile(
     {{/each}}
   {{/each}}
 {{/each}}
-`);
+`
+);
 
 function formatVersions(versions) {
   const haveSkews = !!Object.keys((versions || {}).packages || {}).length;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1284,11 +1284,6 @@ binaryextensions@2:
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.1.1.tgz#3209a51ca4a4ad541a3b8d3d6a6d5b83a2485935"
   integrity sha512-XBaoWE9RW8pPdPQNibZsW2zh8TW6gcarXp1FZPwT8Uop8ScSNldJEWf2k9l3HeTqdrEwsOsFcq74RiJECW34yA==
 
-blessed@^0.1.81:
-  version "0.1.81"
-  resolved "https://registry.yarnpkg.com/blessed/-/blessed-0.1.81.tgz#f962d687ec2c369570ae71af843256e6d0ca1129"
-  integrity sha1-+WLWh+wsNpVwrnGvhDJW5tDKESk=
-
 blob@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
@@ -2292,6 +2287,13 @@ eslint-config-formidable@^4.0.0:
   resolved "https://registry.yarnpkg.com/eslint-config-formidable/-/eslint-config-formidable-4.0.0.tgz#b3a472780e42ae46c288af537e808e45f8b7c6dd"
   integrity sha512-q23C58Kf24Ob4dlwZQE5/JwvmrQ1UyxsW1j8+jNJgDKh+KhEySj3DRGkzy3lJ0556AEApGYoU7IC4gvmJ7iiKA==
 
+eslint-config-prettier@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-4.0.0.tgz#16cedeea0a56e74de60dcbbe3be0ab2c645405b9"
+  integrity sha512-kWuiJxzV5NwOwZcpyozTzDT5KJhBw292bbYro9Is7BWnbNMg15Gmpluc1CTetiCatF8DRkNvgPAOaSyg+bYr3g==
+  dependencies:
+    get-stdin "^6.0.0"
+
 eslint-import-resolver-node@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz#58f15fb839b8d0576ca980413476aab2472db66a"
@@ -2333,6 +2335,13 @@ eslint-plugin-import@^2.12.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
+
+eslint-plugin-prettier@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz#19d521e3981f69dd6d14f64aec8c6a6ac6eb0b0d"
+  integrity sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
 
 eslint-plugin-promise@^3.7.0:
   version "3.7.0"
@@ -2552,6 +2561,11 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^2.0.2:
   version "2.2.2"
@@ -2795,6 +2809,11 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
 get-stream@3.0.0, get-stream@^3.0.0:
   version "3.0.0"
@@ -4390,6 +4409,11 @@ neo-async@^2.5.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.5.1.tgz#acb909e327b1e87ec9ef15f41b8a269512ad41ee"
   integrity sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==
 
+neo-blessed@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/neo-blessed/-/neo-blessed-0.2.0.tgz#30f9495fdd104494402b62c6273a9c9b82de4f2b"
+  integrity sha512-C2kC4K+G2QnNQFXUIxTQvqmrdSIzGTX1ZRKeDW6ChmvPRw8rTkTEJzbEQHiHy06d36PCl/yMOCjquCRV8SpSQw==
+
 nice-try@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
@@ -4990,6 +5014,18 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@^1.16.4:
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.16.4.tgz#73e37e73e018ad2db9c76742e2647e21790c9717"
+  integrity sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==
 
 prettier@^1.5.3:
   version "1.12.1"


### PR DESCRIPTION
This PR migrates us to using [`neo-blessed`](https://github.com/embark-framework/neo-blessed) 🎉, an actively maintained fork of `blessed`. After doing some experimentation to look at a full rewrite with [`react-blessed`](https://github.com/Yomguithereal/react-blessed) or [`ink`](https://github.com/vadimdemedes/ink/tree/next), I found significant drawbacks to each.

With `react-blessed`, there are some weird behaviors with some of the core styling APIs of `blessed` (for example, using `padding` breaks layout entirely). Moreover, the attributes supplied to JSX nodes in `react-blessed` just desugar to calls to `blessed` anyways, so we don't get any underlying enhancements for what would be a considerable migration.

`ink` isn't really in the same mold as `blessed` and doesn't allow you to commandeer the terminal screen, so it feels like it'd be too much of a departure from what we currently have to justify the migration. We should definitely consider it for future CLIs tho!

This PR also adds Prettier to the codebase. We use ESLint to run Prettier, so we shouldn't get any ESLint errors with this setup. We also expose a `format` script for users to run (assuming they don't already have their editor configured to format on save) and a `format:check` script that we run in CI to ensure formatting is consistent across PRs. There are no code changes in this PR, so any changes you see are purely Prettier rewrites.