### PR TITLE
#272 Use process.kill with SIGINT to terminate dashboard process.

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+examples/**/dist-*/*.js
+examples/**/dist-*/*.json

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -85,8 +85,7 @@ class Dashboard {
     }
 
     this.screen.key(["escape", "q", "C-c"], () => {
-      // eslint-disable-next-line no-process-exit
-      process.exit(0);
+      process.kill(process.pid, "SIGINT");
     });
 
     this.screen.render();

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cross-spawn": "^6.0.5",
     "filesize": "^3.6.1",
     "handlebars": "^4.1.0",
-    "inspectpack": "^4.0.0",
+    "inspectpack": "^4.2.0",
     "most": "^1.7.3",
     "neo-blessed": "^0.2.0",
     "socket.io": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2324,10 +2324,10 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inspectpack@^4.0.0:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/inspectpack/-/inspectpack-4.1.2.tgz#b07dd10f1131c290d2076270470787d61b47097e"
-  integrity sha512-bd0iIr5P2xRMtjQQkPnUYJSNa3mUFYER/2eQOPAoXrWBnZXMeFVAgRt/Dny8XVdSkkFoNKhumPjjV9QgTDcVxQ==
+inspectpack@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/inspectpack/-/inspectpack-4.2.0.tgz#13ff46a4d8258f7b6e79f4db5ed9935d37470a13"
+  integrity sha512-K8GY9cBak4DZg6lJYk22xD1b9i975q5KVqtIv/MNXq8OhuZL3OcXyZcZX/oq7xxFpkR8KW/9KyogE6+zcl48KQ==
   dependencies:
     chalk "^2.4.0"
     io-ts "^1.0.5"


### PR DESCRIPTION
This PR addresses #272, which is based off of https://github.com/FormidableLabs/nodejs-dashboard/pull/93. After doing some digging in the [`neo-blessed` source](https://github.com/embark-framework/neo-blessed/blob/master/lib/widgets/screen.js#L225-L235), it appears that they support sending `SIGINT` as a way to gracefully exit the dashboard process if no other handlers exist for that signal. From all the local testing I've done, this doesn't appear to interfere with any existing dashboard functionality. Would love another person to do a local pull of this branch for final verification, but otherwise I don't see much downside in shipping this. Once merged, I'll release 3.0.1 that also includes some security fixes.