### PR TITLE
BUG: Handle large webpack stats bundles without socket.io client disconnect.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yarn-error.log
 package-lock.json
 dist-*
 .vscode
+.lankrc.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Change Log
 
-This project adheres to [Semantic Versioning](http://semver.org/).  
+This project adheres to [Semantic Versioning](http://semver.org/).
 Every release, along with the migration instructions, is documented on the Github [Releases](https://github.com/FormidableLabs/webpack-dashboard/releases) page.
+
+## UNRELEASED
+
+### Bugs
+
+- **Socket.io disconnects / large stats object size**: Dramatically reduce the size of the webpack stats object being sent from client (webpack plugin) to server (CLI). Add client error/disconnect information for better future debugging. Original issue: https://github.com/FormidableLabs/inspectpack/issues/279 and fix: https://github.com/FormidableLabs/inspectpack/pull/281
 
 ## [3.0.2] - 2019-03-28
 

--- a/bin/webpack-dashboard.js
+++ b/bin/webpack-dashboard.js
@@ -65,9 +65,9 @@ const main = (module.exports = opts => {
     server.on("connection", socket => {
       socket.emit("mode", { minimal: program.minimal || false });
 
-      socket.on("message", message => {
+      socket.on("message", (message, ack) => {
         if (message.type !== "log") {
-          dashboard.setData(message);
+          dashboard.setData(message, ack);
         }
       });
     });
@@ -95,8 +95,8 @@ const main = (module.exports = opts => {
     });
   } else {
     server.on("connection", socket => {
-      socket.on("message", message => {
-        dashboard.setData(message);
+      socket.on("message", (message, ack) => {
+        dashboard.setData(message, ack);
       });
     });
   }

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -91,7 +91,7 @@ class Dashboard {
     this.screen.render();
   }
 
-  setData(dataArray) {
+  setData(dataArray, ack) {
     dataArray
       .map(data =>
         data.error
@@ -105,6 +105,11 @@ class Dashboard {
       });
 
     this.screen.render();
+
+    // Send ack back if requested.
+    if (ack) {
+      ack();
+    }
   }
 
   setProgress(data) {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -71,15 +71,16 @@ class DashboardPlugin {
   }
 
   apply(compiler) {
+    let handler = this.handler;
     let timer;
 
-    if (!this.handler) {
-      this.handler = noop;
+    if (!handler) {
+      handler = noop;
       const port = this.port;
       const host = this.host;
       this.socket = new SocketIOClient(`http://${host}:${port}`);
       this.socket.on("connect", () => {
-        this.handler = this.socket.emit.bind(this.socket, "message");
+        handler = this.socket.emit.bind(this.socket, "message");
       });
       this.socket.once("mode", args => {
         this.minimal = args.minimal;
@@ -95,7 +96,7 @@ class DashboardPlugin {
     }
 
     new webpack.ProgressPlugin((percent, msg) => {
-      this.handler([
+      handler([
         {
           type: "status",
           value: "Compiling"
@@ -123,7 +124,7 @@ class DashboardPlugin {
 
     webpackHook(compiler, "compile", () => {
       timer = Date.now();
-      this.handler([
+      handler([
         {
           type: "status",
           value: "Compiling"
@@ -132,7 +133,7 @@ class DashboardPlugin {
     });
 
     webpackHook(compiler, "invalid", () => {
-      this.handler([
+      handler([
         {
           type: "status",
           value: "Invalidated"
@@ -152,7 +153,7 @@ class DashboardPlugin {
     });
 
     webpackHook(compiler, "failed", () => {
-      this.handler([
+      handler([
         {
           type: "status",
           value: "Failed"
@@ -195,7 +196,7 @@ class DashboardPlugin {
         console.error(err);
       }
 
-      this.handler([
+      handler([
         {
           type: "status",
           value: "Success"
@@ -224,7 +225,7 @@ class DashboardPlugin {
 
       if (!this.minimal) {
         this.observeMetrics(stats).subscribe({
-          next: message => this.handler([message]),
+          next: message => handler([message]),
           error: err => {
             console.log("Error from inspectpack:", err); // eslint-disable-line no-console
             this.cleanup();

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -91,7 +91,7 @@ class DashboardPlugin {
       });
       this.socket.on("disconnect", () => {
         // eslint-disable-next-line no-console
-        console.log("Socket.io disconnected. Possibly build data too large?");
+        console.log("Socket.io disconnected.");
       });
     }
 


### PR DESCRIPTION
## Current Notes

Thanks to great insight by @westbrook-asapp it appears we're sending the full webpack stats object from client (webpack plugin) to server (CLI) when we **only** need the errors and warnings fields. This PR:

- Limits the webpack stats messaged object to just errors and warnings. Fixes #279 
- Add client disconnect / error messages to help analogous issues in the future.

/cc @parkerziegler @westbrook-asapp

## Old, WIP debugging info
Currently can reproduce the bug in #279 as follows:

```sh
$ yarn

# Run normally. => NO DISCONNECT MESSAGE / WORKS
$ cross-env EXAMPLE=simple node bin/webpack-dashboard.js -- webpack-cli --config examples/config/webpack.config.js --watch

# Run with hack to inject a **huge** source payload. => "Socket.io disconnected. Possibly build data too large?"
$ cross-env EXAMPLE=simple TMP_BIG_STATS=true node bin/webpack-dashboard.js -- webpack-cli --config examples/config/webpack.config.js --watch
```

I haven't started at looking at solutions, but we've easily now captured the error with the large payload size from @westbrook-asapp . I've even attempted to further refine the "bad" threshold in code, although that may well be machine dependent?

I think next step is see if there is some issue in socket.io that has potential solutions (either in client or server) or something else...
