### PR TITLE
Add left/right navigation to move between modules

### DIFF
--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -303,6 +303,20 @@ class Dashboard {
       this.logText.scroll(1);
       this.logText.screen.render();
     });
+    this.screen.key(["left"], () => {
+      const currentIndex = this.modulesMenu.selected;
+      this.modulesMenu.selectTab(currentIndex - 1);
+      this.problemsMenu.selectTab(currentIndex - 1);
+      this.problemsMenu.screen.render();
+      this.modulesMenu.screen.render();
+    });
+    this.screen.key(["right"], () => {
+      const currentIndex = this.modulesMenu.selected;
+      this.modulesMenu.selectTab(currentIndex + 1);
+      this.problemsMenu.selectTab(currentIndex + 1);
+      this.problemsMenu.screen.render();
+      this.modulesMenu.screen.render();
+    });
   }
 
   layoutModules() {


### PR DESCRIPTION
When we have more than 5 modules (depends on the name size) we can't select it with mouse anymore.
So I think we can use left/right keys to switch between modules.