### PR TITLE
[Docs]: minor tweak

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Error output deeply inspired by: [https://github.com/facebookincubator/create-re
 
 [maintenance-image]: https://img.shields.io/badge/maintenance-active-green.svg
 [npm_img]: https://img.shields.io/npm/v/webpack-dashboard.svg?style=flat
-[npm_site]: https://github.com/FormidableLabs/webpack-dashboard/
+[npm_site]: https://www.npmjs.com/package/webpack-dashboard
 [trav_img]: https://api.travis-ci.org/FormidableLabs/webpack-dashboard.svg
 [trav_site]: https://travis-ci.org/FormidableLabs/webpack-dashboard
 [appveyor_img]: https://ci.appveyor.com/api/projects/status/github/formidablelabs/webpack-dashboard?branch=master&svg=true


### PR DESCRIPTION
Made the `npm` version badge link up to the respective `npm` page