### PR TITLE
fix: 🐛 Add chalk to package.json to fix implicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "webpack": "*"
   },
   "dependencies": {
+    "chalk": "^2.0.0",
     "commander": "^2.15.1",
     "cross-spawn": "^6.0.5",
     "filesize": "^3.6.1",


### PR DESCRIPTION
Add chalk to package.json to fix implicit dependency as this will break in Yarn 2

✅ Closes: #308