### PR TITLE
Bugfix: Ensure status is updated correctly on compilation finishing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 Every release, along with the migration instructions, is documented on the Github [Releases](https://github.com/FormidableLabs/webpack-dashboard/releases) page.
 
+## UNRELEASED
+
+- Bugfix: Ensure `Status` is properly updating and reaches completion. Fixes #321
+
 ## [3.3.0] - 2021-01-21
 
 - Add `webpack@5` support. Closes #316

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -142,6 +142,9 @@ class Dashboard {
       case "Failed":
         content = `{red-fg}{bold}${data.value}{/}`;
         break;
+      case "Error":
+        content = `{red-fg}{bold}${data.value}{/}`;
+        break;
       default:
         content = `{bold}${data.value}{/}`;
     }

--- a/examples/duplicates-esm/src/index.js
+++ b/examples/duplicates-esm/src/index.js
@@ -1,6 +1,5 @@
 /* eslint-disable no-console*/
-// TODO: HERE FORCE AN ERROR,
-?/}BAD
+
 import { foo } from "foo";
 import { usesFoo } from "uses-foo";
 

--- a/examples/duplicates-esm/src/index.js
+++ b/examples/duplicates-esm/src/index.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-console*/
+// TODO: HERE FORCE AN ERROR,
+?/}BAD
 import { foo } from "foo";
 import { usesFoo } from "uses-foo";
 

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -101,6 +101,10 @@ class DashboardPlugin {
     }
 
     new webpack.ProgressPlugin((percent, msg) => {
+      console.log("TODO webpack.ProgressPlugin", { status: "Compiling", percent, msg });
+      // TODO HERE: Review lifecycle and cap off once get past lifecycle where done is.
+      // TODO: Could track state on `done` and reset when below 0.1 or something.
+      // const status = percent === 1
       handler([
         {
           type: "status",
@@ -129,6 +133,7 @@ class DashboardPlugin {
 
     webpackHook(compiler, "compile", () => {
       timer = Date.now();
+      console.log("TODO hook.compile", { status: "Compiling" });
       handler([
         {
           type: "status",
@@ -138,6 +143,7 @@ class DashboardPlugin {
     });
 
     webpackHook(compiler, "invalid", () => {
+      console.log("TODO hook.invalid", { status: "Invalidated" });
       handler([
         {
           type: "status",
@@ -158,6 +164,7 @@ class DashboardPlugin {
     });
 
     webpackHook(compiler, "failed", () => {
+      console.log("TODO hook.failed", { status: "Failed" });
       handler([
         {
           type: "status",
@@ -171,9 +178,10 @@ class DashboardPlugin {
     });
 
     webpackHook(compiler, "done", stats => {
-      const options = stats.compilation.options;
+      const { errors, options } = stats.compilation;
       const statsOptions = (options.devServer && options.devServer.stats) ||
         options.stats || { colors: true };
+      const status = !!errors.length  ? "Error" : "Success";
 
       // We only need errors/warnings for stats information for finishing up.
       // This allows us to avoid sending a full stats object to the CLI which
@@ -185,11 +193,12 @@ class DashboardPlugin {
         warnings: true
       };
 
+      console.log("TODO hook.failed", { status });
       handler(
         [
           {
             type: "status",
-            value: "Success"
+            value: status
           },
           {
             type: "progress",


### PR DESCRIPTION
- Ensure a finished compilation state (failed, error, success) isn't overwritten by the ProgressPlugin. Fixes #321 
- Add error status inferred from webpack stats.