### PR TITLE
Chore: Various plugin refactoring and simplification.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Every release, along with the migration instructions, is documented on the Githu
 
 - Chore: Refactor internal stats consumption to perform `inspectpack` analysis in the main thread, without using `main` streams.
 - Chore: Refactor internal handler in plugin to always be a wrapped function so that we can't accidentally have asynchronous code call the handler function after it is removed / nulled.
+- Bugfix: Add message counting delayed cleanup in plugin to allow messages to drain in Dashboard. Fixes [#294](https://github.com/FormidableLabs/webpack-dashboard/issues/294).
 
 ## [3.3.3] - 2021-05-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 Every release, along with the migration instructions, is documented on the Github [Releases](https://github.com/FormidableLabs/webpack-dashboard/releases) page.
 
+## UNRELEASED
+
+- Chore: Refactor internal stats consumption to perform `inspectpack` analysis in the main thread, without using `main` streams.
+
 ## [3.3.3] - 2021-05-05
 
 - Security: Update `socket.io` version to get rid of vulnerable `xmlhttprequest-ssl` package. Included in: https://github.com/FormidableLabs/webpack-dashboard/pull/325 by @texpert.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Every release, along with the migration instructions, is documented on the Githu
 ## UNRELEASED
 
 - Chore: Refactor internal stats consumption to perform `inspectpack` analysis in the main thread, without using `main` streams.
+- Chore: Refactor internal handler in plugin to always be a wrapped function so that we can't accidentally have asynchronous code call the handler function after it is removed / nulled.
 
 ## [3.3.3] - 2021-05-05
 

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -100,14 +100,6 @@ class Dashboard {
           : data
       )
       .forEach(data => {
-        if (data.type !== "log") {
-          this.setLog({
-            value: `DASHBOARD -- TODO setData MESSAGE: ${JSON.stringify({
-              type: data.type
-            })}`
-          });
-        }
-
         this.actionForMessageType[data.type](data);
       });
 

--- a/dashboard/index.js
+++ b/dashboard/index.js
@@ -36,7 +36,6 @@ class Dashboard {
     this.stats = null;
 
     // Data binding, lookup tables.
-    this.setData = this.setData.bind(this);
     this.actionForMessageType = {
       progress: this.setProgress.bind(this),
       operations: this.setOperations.bind(this),
@@ -101,6 +100,14 @@ class Dashboard {
           : data
       )
       .forEach(data => {
+        if (data.type !== "log") {
+          this.setLog({
+            value: `DASHBOARD -- TODO setData MESSAGE: ${JSON.stringify({
+              type: data.type
+            })}`
+          });
+        }
+
         this.actionForMessageType[data.type](data);
       });
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "filesize": "^6.1.0",
     "handlebars": "^4.1.2",
     "inspectpack": "^4.6.1",
-    "most": "^1.7.3",
     "neo-blessed": "^0.2.0",
     "socket.io": "^4.0.1",
     "socket.io-client": "^4.0.1"

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -62,17 +62,22 @@ class DashboardPlugin {
   }
 
   cleanup() {
+    // eslint-disable-next-line no-console
     console.log("PLUGIN -- TODO HERE CLEANUP", {
       watching: this.watching,
       socket: !!this.socket
     });
     if (!this.watching && this.socket) {
       this.handler = null;
-      this.socket.close();
-      // setTimeout(() => {
-      //   console.log("PLUGIN -- TODO HERE CLOSE")
-      //   this.socket.close();
-      // }, 1000);
+
+      // TODO: REFACTOR
+      // TODO: Extract wait period and comment why
+      // this.socket.close();
+      setTimeout(() => {
+        // eslint-disable-next-line no-console
+        console.log("PLUGIN -- TODO HERE CLOSE");
+        this.socket.close();
+      }, 1000); // eslint-disable-line no-magic-numbers
     }
   }
 

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -101,13 +101,17 @@ class DashboardPlugin {
       const host = this.host;
       this.socket = io(`http://${host}:${port}`);
       this.socket.on("connect", () => {
-        // TODO: REFACTOR AND COMMENT
+        // Manually track messages we send to the dashboard and decrement later.
         const socketMsg = this.socket.emit.bind(this.socket, "message");
         this._handler = (...args) => {
           this.openMessages++;
-          socketMsg(...args, () => {
-            this.openMessages--;
-          });
+          socketMsg(
+            ...args.concat([
+              () => {
+                this.openMessages--;
+              }
+            ])
+          );
         };
       });
       this.socket.once("options", args => {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -103,15 +103,12 @@ class DashboardPlugin {
       this.socket.on("connect", () => {
         // Manually track messages we send to the dashboard and decrement later.
         const socketMsg = this.socket.emit.bind(this.socket, "message");
+        const ack = () => {
+          this.openMessages--;
+        };
         this._handler = (...args) => {
           this.openMessages++;
-          socketMsg(
-            ...args.concat([
-              () => {
-                this.openMessages--;
-              }
-            ])
-          );
+          socketMsg(...args, ack);
         };
       });
       this.socket.once("options", args => {

--- a/test/plugin/index.spec.js
+++ b/test/plugin/index.spec.js
@@ -83,17 +83,16 @@ describe("plugin", () => {
     it("can do a basic compilation", () => {
       expect(() => plugin.apply(compiler)).to.not.throw;
 
-      // after instantiation, test that we can hit observeMetrics
-      expect(() => plugin.observeMetrics({ toJson })).to.not.throw;
+      // after instantiation, test that we can hit getMetrics
+      expect(() => plugin.getMetrics({ toJson })).to.not.throw;
     });
 
-    it("can do a basic observeMetrics", () => {
+    it("can do a basic getMetrics", () => {
       const actions = base.sandbox.spy(inspectpackActions, "actions");
 
       return (
         plugin
-          .observeMetrics({ toJson })
-          .drain()
+          .getMetrics({ toJson })
           // eslint-disable-next-line promise/always-return
           .then(() => {
             expect(actions).to.have.been.calledThrice;
@@ -130,8 +129,7 @@ describe("plugin", () => {
 
       return (
         plugin
-          .observeMetrics({ toJson })
-          .drain()
+          .getMetrics({ toJson })
           // eslint-disable-next-line promise/always-return
           .then(() => {
             expect(actions).to.have.been.calledWith("sizes", {
@@ -152,8 +150,7 @@ describe("plugin", () => {
 
       return (
         plugin
-          .observeMetrics({ toJson })
-          .drain()
+          .getMetrics({ toJson })
           // eslint-disable-next-line promise/always-return
           .then(() => {
             // All three actions called.

--- a/test/plugin/index.spec.js
+++ b/test/plugin/index.spec.js
@@ -18,7 +18,7 @@ describe("plugin", () => {
     expect(plugin.host).to.equal("127.0.0.1");
     // eslint-disable-next-line no-magic-numbers
     expect(plugin.port).to.equal(9838);
-    expect(plugin.handler).to.be.null;
+    expect(plugin._handler).to.be.null;
     expect(plugin.watching).to.be.false;
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -213,18 +213,6 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
 
-"@most/multicast@^1.2.5":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@most/multicast/-/multicast-1.3.0.tgz#e01574840df634478ac3fabd164c6e830fb3b966"
-  integrity sha512-DWH8AShgp5bXn+auGzf5tzPxvpmEvQJd0CNsApOci1LDF4eAEcnw4HQOr2Jaa+L92NbDYFKBSXxll+i7r1ikvw==
-  dependencies:
-    "@most/prelude" "^1.4.0"
-
-"@most/prelude@^1.4.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.8.0.tgz#90814b9e92d538e2d1c6eb69c01dfe4e86b5c80e"
-  integrity sha512-t1CcURpZzfmBA6fEWwqmCqeNzWAj1w2WqEmCk/2yXMe/p8Ut000wFmVKMy8A1Rl9VVxZEZ5nBHd/pU0dR4bv/w==
-
 "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.8.1":
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.2.tgz#858f5c4b48d80778fde4b9d541f27edc0d56488b"
@@ -1548,13 +1536,6 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
-globalthis@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.1.tgz#40116f5d9c071f9e8fb0037654df1ab3a83b7ef9"
-  integrity sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==
-  dependencies:
-    define-properties "^1.1.3"
-
 graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
@@ -2159,16 +2140,6 @@ mocha@^8.2.1:
     yargs "13.3.2"
     yargs-parser "13.1.2"
     yargs-unparser "2.0.0"
-
-most@^1.7.3:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/most/-/most-1.9.0.tgz#a689b1191a67c25776068b00cf3446e429752743"
-  integrity sha512-M7yHMcMGaclzEL6eg8Yh8PlAsaWfL/oSThF4+ZuWKM5CKXcbzmLh+qESwgZFzMKHJ+iVJwb28yFvDEOobI653w==
-  dependencies:
-    "@most/multicast" "^1.2.5"
-    "@most/prelude" "^1.4.0"
-    globalthis "^1.0.1"
-    symbol-observable "^2.0.3"
 
 ms@2.0.0:
   version "2.0.0"
@@ -3052,11 +3023,6 @@ supports-color@^5.3.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
-
-symbol-observable@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
-  integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
 
 table@^6.0.4:
   version "6.0.7"


### PR DESCRIPTION
Refactors the plugin internal logic to be a lot simpler. 

- Chore: Refactor internal stats consumption to perform `inspectpack` analysis in the main thread, without using `main` streams. Originally, the `inspectpack` engine did some really heavy CPU stuff (gzipping lots of files), but now the actions are super fast, so I've removed `most` async observables and just switched to straight promises.
- Chore: Refactor internal handler in plugin to always be a wrapped function so that we can't accidentally have asynchronous code call the handler function after it is removed / nulled.
- Bugfix: Add message counting delayed cleanup in plugin to allow messages to drain in Dashboard. The issue seems to be that we hit socket IO disconnect in the plugin before the dashboard actually processes the messages. Fixes #294.

@peterhpchen -- Can you check this in your webpack v4 and v5 projects? (And if you get a chance in non-watch and watched modes?) Thanks!!!